### PR TITLE
Refactor network interfaces and Asio plugins

### DIFF
--- a/client/src/client.cpp
+++ b/client/src/client.cpp
@@ -59,8 +59,8 @@ cli::Client::Client(const ArgsConfig &cfg)
         !cfg.game_multi_lib_path.empty() ? cfg.game_multi_lib_path : Path::Plugin::PLUGIN_GAME_MULTI.string());
     m_engine->getRenderer()->createWindow("R-Type Client", m_config.height, m_config.width, m_config.frameLimit,
                                           m_config.fullscreen);
+    m_engine->getNetwork()->setPlayerName("Bobi");
     m_engine->getNetwork()->connect(m_config.host, m_config.port);
-    m_engine->getNetwork()->sendConnect("Bobi");
     setupScenes();
 }
 

--- a/modules/Interfaces/include/Interfaces/INetworkClient.hpp
+++ b/modules/Interfaces/include/Interfaces/INetworkClient.hpp
@@ -7,15 +7,23 @@
 #pragma once
 
 #include <cstdint>
-#include <functional>
 #include <string>
-#include <vector>
 
-#include "Interfaces/Protocol/Protocol.hpp"
 #include "Utils/Interfaces/IPlugin.hpp"
 
 namespace eng
 {
+
+    ///
+    /// @brief Connection state enumeration
+    ///
+    enum class ConnectionState
+    {
+        DISCONNECTED,
+        CONNECTING,
+        CONNECTED,
+        DISCONNECTING
+    };
 
     ///
     /// @class INetworkClient
@@ -25,33 +33,25 @@ namespace eng
     class INetworkClient : public utl::IPlugin
     {
         public:
-            using PacketHandler = std::function<void(const rnp::PacketHeader &, const std::vector<uint8_t> &)>;
-
             virtual ~INetworkClient() = default;
 
             // Connection management
             virtual void connect(const std::string &host, uint16_t port) = 0;
             virtual void disconnect() = 0;
 
-            // Protocol messages
-            virtual void sendConnect(const std::string &playerName) = 0;
-            virtual void sendConnectWithCaps(const std::string &playerName, std::uint32_t clientCaps) = 0;
-            virtual void sendDisconnect() = 0;
-            virtual void sendDisconnect(rnp::DisconnectReason reason) = 0;
-            virtual void sendPlayerInput(uint8_t direction, uint8_t shooting) = 0;
-            virtual void sendPlayerInputAsEvent(std::uint16_t playerId, uint8_t direction, uint8_t shooting,
-                                                uint32_t clientTimeMs) = 0;
-            virtual void sendPing() = 0;
-            virtual void sendPing(std::uint32_t nonce, std::uint32_t sendTimeMs) = 0;
-            virtual void sendAck(std::uint32_t cumulative, std::uint32_t ackBits) = 0;
+            // Packet handling
+            virtual void update() = 0;
 
-            // Handler management
-            virtual void setPacketHandler(rnp::PacketType type, PacketHandler handler) = 0;
-            virtual void setEventsHandler(std::function<void(const std::vector<rnp::EventRecord> &)> handler) = 0;
+            // Connection status
+            [[nodiscard]] virtual bool isConnected() const = 0;
+            [[nodiscard]] virtual ConnectionState getConnectionState() const = 0;
+            [[nodiscard]] virtual std::uint32_t getSessionId() const = 0;
+            [[nodiscard]] virtual std::uint16_t getServerTickRate() const = 0;
+            [[nodiscard]] virtual std::uint32_t getLatency() const = 0;
 
-            // Getters
-            virtual std::uint32_t getSessionId() const = 0;
-            virtual std::uint16_t getServerTickRate() const = 0;
+            // Client configuration
+            virtual void setPlayerName(const std::string &playerName) = 0;
+            virtual void setClientCapabilities(std::uint32_t caps) = 0;
 
         private:
     }; // class INetworkClient

--- a/modules/Interfaces/include/Interfaces/INetworkServer.hpp
+++ b/modules/Interfaces/include/Interfaces/INetworkServer.hpp
@@ -7,11 +7,9 @@
 #pragma once
 
 #include <cstdint>
-#include <functional>
 #include <string>
 #include <vector>
 
-#include "Interfaces/Protocol/Protocol.hpp"
 #include "Utils/Interfaces/IPlugin.hpp"
 
 namespace srv
@@ -31,9 +29,22 @@ namespace srv
         public:
             virtual ~INetworkServer() = default;
 
+            // Server lifecycle
             virtual void init(const std::string &host, uint16_t port) = 0;
             virtual void start() = 0;
             virtual void stop() = 0;
+            virtual void update() = 0;
+
+            // Client management
+            virtual void sendToClient(std::uint32_t sessionId, const std::vector<std::uint8_t> &data,
+                                      bool reliable = false) = 0;
+            virtual void sendToAllClients(const std::vector<std::uint8_t> &data, bool reliable = false) = 0;
+            virtual void disconnectClient(std::uint32_t sessionId) = 0;
+
+            // Server information
+            [[nodiscard]] virtual std::size_t getClientCount() const = 0;
+            [[nodiscard]] virtual std::vector<std::uint32_t> getConnectedSessions() const = 0;
+            [[nodiscard]] virtual bool isRunning() const = 0;
 
             // Configuration
             virtual void setTickRate(std::uint16_t tickRate) = 0;

--- a/modules/Interfaces/include/Interfaces/Protocol/HandlerPacket.hpp
+++ b/modules/Interfaces/include/Interfaces/Protocol/HandlerPacket.hpp
@@ -1,0 +1,388 @@
+///
+/// @file HandlerPacket.hpp
+/// @brief Network packet handler for RNP protocol
+/// @namespace rnp
+///
+
+#pragma once
+
+#include "Protocol.hpp"
+#include "Serializer.hpp"
+#include <chrono>
+#include <functional>
+#include <memory>
+#include <stdexcept>
+#include <unordered_map>
+
+namespace rnp
+{
+
+    ///
+    /// @brief Packet processing result
+    ///
+    enum class HandlerResult
+    {
+        SUCCESS,
+        INVALID_PACKET,
+        UNSUPPORTED_TYPE,
+        PROCESSING_ERROR,
+        SESSION_INVALID,
+        RATE_LIMITED
+    };
+
+    ///
+    /// @brief Context information for packet processing
+    ///
+    struct PacketContext
+    {
+            std::uint32_t sessionId;
+            std::chrono::steady_clock::time_point receiveTime;
+            std::string senderAddress;
+            std::uint16_t senderPort;
+            bool isReliable;
+            bool isCompressed;
+    };
+
+    ///
+    /// @brief Forward declarations for callback types
+    ///
+    class HandlerPacket;
+
+    using ConnectHandler = std::function<HandlerResult(const PacketConnect &, const PacketContext &)>;
+    using ConnectAcceptHandler = std::function<HandlerResult(const PacketConnectAccept &, const PacketContext &)>;
+    using DisconnectHandler = std::function<HandlerResult(const PacketDisconnect &, const PacketContext &)>;
+    using WorldStateHandler = std::function<HandlerResult(const PacketWorldState &, const PacketContext &)>;
+    using PingHandler = std::function<HandlerResult(const PacketPingPong &, const PacketContext &)>;
+    using PongHandler = std::function<HandlerResult(const PacketPingPong &, const PacketContext &)>;
+    using ErrorHandler = std::function<HandlerResult(const PacketError &, const PacketContext &)>;
+    using EntityEventHandler = std::function<HandlerResult(const std::vector<EventRecord> &, const PacketContext &)>;
+    using AckHandler = std::function<HandlerResult(std::uint32_t sequenceId, const PacketContext &)>;
+
+    ///
+    /// @brief Statistics for packet handling
+    ///
+    struct HandlerStats
+    {
+            std::uint64_t totalPacketsReceived = 0;
+            std::uint64_t totalPacketsProcessed = 0;
+            std::uint64_t totalPacketsDropped = 0;
+            std::uint64_t totalBytesReceived = 0;
+            std::unordered_map<PacketType, std::uint64_t> packetTypeCount;
+            std::unordered_map<HandlerResult, std::uint64_t> resultCount;
+    };
+
+    ///
+    /// @brief Main packet handler class
+    ///
+    class HandlerPacket
+    {
+        private:
+            // Handler callbacks
+            ConnectHandler connectHandler_;
+            ConnectAcceptHandler connectAcceptHandler_;
+            DisconnectHandler disconnectHandler_;
+            WorldStateHandler worldStateHandler_;
+            PingHandler pingHandler_;
+            PongHandler pongHandler_;
+            ErrorHandler errorHandler_;
+            EntityEventHandler entityEventHandler_;
+            AckHandler ackHandler_;
+
+            // Statistics
+            HandlerStats stats_;
+
+            // Rate limiting (simple token bucket per session)
+            std::unordered_map<std::uint32_t, std::chrono::steady_clock::time_point> lastPacketTime_;
+            std::chrono::milliseconds rateLimitInterval_{10}; // 10ms minimum between packets
+
+            ///
+            /// @brief Check rate limiting for a session
+            /// @param sessionId Session to check
+            /// @param currentTime Current time
+            /// @return True if packet should be rate limited
+            ///
+            bool isRateLimited(std::uint32_t sessionId, const std::chrono::steady_clock::time_point &currentTime)
+            {
+                auto it = lastPacketTime_.find(sessionId);
+                if (it == lastPacketTime_.end())
+                {
+                    lastPacketTime_[sessionId] = currentTime;
+                    return false;
+                }
+
+                auto timeSinceLastPacket = currentTime - it->second;
+                if (timeSinceLastPacket < rateLimitInterval_)
+                {
+                    return true;
+                }
+
+                it->second = currentTime;
+                return false;
+            }
+
+            ///
+            /// @brief Update statistics
+            /// @param packetType Type of packet processed
+            /// @param result Processing result
+            /// @param bytesReceived Number of bytes in the packet
+            ///
+            void updateStats(PacketType packetType, HandlerResult result, std::size_t bytesReceived)
+            {
+                stats_.totalPacketsReceived++;
+                stats_.totalBytesReceived += bytesReceived;
+                stats_.packetTypeCount[packetType]++;
+                stats_.resultCount[result]++;
+
+                if (result == HandlerResult::SUCCESS)
+                {
+                    stats_.totalPacketsProcessed++;
+                }
+                else
+                {
+                    stats_.totalPacketsDropped++;
+                }
+            }
+
+            ///
+            /// @brief Parse and handle ENTITY_EVENT packet
+            /// @param serializer Serializer containing the packet data
+            /// @param payloadSize Size of the payload
+            /// @return Vector of event records
+            ///
+            std::vector<EventRecord> parseEntityEvents(Serializer &serializer, std::size_t payloadSize)
+            {
+                std::vector<EventRecord> events;
+                std::size_t bytesRead = 0;
+
+                while (bytesRead < payloadSize)
+                {
+                    EventRecord event;
+                    event.type = static_cast<EventType>(serializer.readByte());
+                    event.entityId = serializer.readUInt32();
+
+                    std::uint16_t dataLength = serializer.readUInt16();
+                    bytesRead += 7; // 1 + 4 + 2 bytes for type, entityId, dataLength
+
+                    if (dataLength > 0)
+                    {
+                        event.data.resize(dataLength);
+                        serializer.readBytes(event.data.data(), dataLength);
+                        bytesRead += dataLength;
+                    }
+
+                    events.push_back(std::move(event));
+                }
+
+                return events;
+            }
+
+        public:
+            ///
+            /// @brief Constructor
+            ///
+            HandlerPacket() = default;
+
+            ///
+            /// @brief Destructor
+            ///
+            ~HandlerPacket() = default;
+
+            // Delete copy constructor and assignment operator
+            HandlerPacket(const HandlerPacket &) = delete;
+            HandlerPacket &operator=(const HandlerPacket &) = delete;
+
+            ///
+            /// @brief Set rate limiting interval
+            /// @param interval Minimum time between packets per session
+            ///
+            void setRateLimitInterval(std::chrono::milliseconds interval) { rateLimitInterval_ = interval; }
+
+            ///
+            /// @brief Register CONNECT packet handler
+            /// @param handler Callback function for CONNECT packets
+            ///
+            void onConnect(ConnectHandler handler) { connectHandler_ = std::move(handler); }
+
+            ///
+            /// @brief Register CONNECT_ACCEPT packet handler
+            /// @param handler Callback function for CONNECT_ACCEPT packets
+            ///
+            void onConnectAccept(ConnectAcceptHandler handler) { connectAcceptHandler_ = std::move(handler); }
+
+            ///
+            /// @brief Register DISCONNECT packet handler
+            /// @param handler Callback function for DISCONNECT packets
+            ///
+            void onDisconnect(DisconnectHandler handler) { disconnectHandler_ = std::move(handler); }
+
+            ///
+            /// @brief Register WORLD_STATE packet handler
+            /// @param handler Callback function for WORLD_STATE packets
+            ///
+            void onWorldState(WorldStateHandler handler) { worldStateHandler_ = std::move(handler); }
+
+            ///
+            /// @brief Register PING packet handler
+            /// @param handler Callback function for PING packets
+            ///
+            void onPing(PingHandler handler) { pingHandler_ = std::move(handler); }
+
+            ///
+            /// @brief Register PONG packet handler
+            /// @param handler Callback function for PONG packets
+            ///
+            void onPong(PongHandler handler) { pongHandler_ = std::move(handler); }
+
+            ///
+            /// @brief Register ERROR packet handler
+            /// @param handler Callback function for ERROR packets
+            ///
+            void onError(ErrorHandler handler) { errorHandler_ = std::move(handler); }
+
+            ///
+            /// @brief Register ENTITY_EVENT packet handler
+            /// @param handler Callback function for ENTITY_EVENT packets
+            ///
+            void onEntityEvent(EntityEventHandler handler) { entityEventHandler_ = std::move(handler); }
+
+            ///
+            /// @brief Process a received packet
+            /// @param data Raw packet data
+            /// @param context Packet context information
+            /// @return Processing result
+            ///
+            HandlerResult processPacket(const std::vector<std::uint8_t> &data, const PacketContext &context)
+            {
+                if (data.size() < sizeof(PacketHeader))
+                {
+                    updateStats(static_cast<PacketType>(0), HandlerResult::INVALID_PACKET, data.size());
+                    return HandlerResult::INVALID_PACKET;
+                }
+
+                // Check rate limiting
+                if (isRateLimited(context.sessionId, context.receiveTime))
+                {
+                    updateStats(static_cast<PacketType>(0), HandlerResult::RATE_LIMITED, data.size());
+                    return HandlerResult::RATE_LIMITED;
+                }
+
+                try
+                {
+                    Serializer serializer(data);
+                    PacketHeader header = serializer.deserializeHeader();
+
+                    // Validate header
+                    if (header.length > MAX_PAYLOAD || header.sessionId != context.sessionId)
+                    {
+                        updateStats(static_cast<PacketType>(header.type), HandlerResult::INVALID_PACKET, data.size());
+                        return HandlerResult::INVALID_PACKET;
+                    }
+
+                    PacketType packetType = static_cast<PacketType>(header.type);
+                    HandlerResult result = HandlerResult::UNSUPPORTED_TYPE;
+
+                    switch (packetType)
+                    {
+                        case PacketType::CONNECT:
+                            if (connectHandler_)
+                            {
+                                auto packet = serializer.deserializeConnect();
+                                result = connectHandler_(packet, context);
+                            }
+                            break;
+
+                        case PacketType::CONNECT_ACCEPT:
+                            if (connectAcceptHandler_)
+                            {
+                                auto packet = serializer.deserializeConnectAccept();
+                                result = connectAcceptHandler_(packet, context);
+                            }
+                            break;
+
+                        case PacketType::DISCONNECT:
+                            if (disconnectHandler_)
+                            {
+                                auto packet = serializer.deserializeDisconnect();
+                                result = disconnectHandler_(packet, context);
+                            }
+                            break;
+
+                        case PacketType::WORLD_STATE:
+                            if (worldStateHandler_)
+                            {
+                                auto packet = serializer.deserializeWorldState();
+                                result = worldStateHandler_(packet, context);
+                            }
+                            break;
+
+                        case PacketType::PING:
+                            if (pingHandler_)
+                            {
+                                auto packet = serializer.deserializePingPong();
+                                result = pingHandler_(packet, context);
+                            }
+                            break;
+
+                        case PacketType::PONG:
+                            if (pongHandler_)
+                            {
+                                auto packet = serializer.deserializePingPong();
+                                result = pongHandler_(packet, context);
+                            }
+                            break;
+
+                        case PacketType::PACKET_ERROR:
+                            if (errorHandler_)
+                            {
+                                auto packet = serializer.deserializeError();
+                                result = errorHandler_(packet, context);
+                            }
+                            break;
+
+                        case PacketType::ENTITY_EVENT:
+                            if (entityEventHandler_)
+                            {
+                                auto events = parseEntityEvents(serializer, header.length);
+                                result = entityEventHandler_(events, context);
+                            }
+                            break;
+
+                        default:
+                            result = HandlerResult::UNSUPPORTED_TYPE;
+                            break;
+                    }
+
+                    updateStats(packetType, result, data.size());
+                    return result;
+                }
+                catch (const std::exception &)
+                {
+                    updateStats(static_cast<PacketType>(0), HandlerResult::PROCESSING_ERROR, data.size());
+                    return HandlerResult::PROCESSING_ERROR;
+                }
+            }
+
+            ///
+            /// @brief Get handler statistics
+            /// @return Current statistics
+            ///
+            const HandlerStats &getStats() const { return stats_; }
+
+            ///
+            /// @brief Reset statistics
+            ///
+            void resetStats() { stats_ = HandlerStats{}; }
+
+            ///
+            /// @brief Clear rate limiting data for a session
+            /// @param sessionId Session to clear
+            ///
+            void clearSession(std::uint32_t sessionId) { lastPacketTime_.erase(sessionId); }
+
+            ///
+            /// @brief Clear all rate limiting data
+            ///
+            void clearAllSessions() { lastPacketTime_.clear(); }
+    };
+
+} // namespace rnp

--- a/modules/Interfaces/include/Interfaces/Protocol/Protocol.hpp
+++ b/modules/Interfaces/include/Interfaces/Protocol/Protocol.hpp
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <array>
 #include <cstdint>
 #include <cstring>
 #include <stdexcept>
@@ -14,7 +15,6 @@
 namespace rnp
 {
 
-    inline constexpr std::uint8_t PROTOCOL_VERSION = 1;
     inline constexpr std::size_t MAX_PAYLOAD = 512;
 
     ///
@@ -28,10 +28,8 @@ namespace rnp
         PING = 0x04,
         PONG = 0x05,
         PACKET_ERROR = 0x06,
-        ACK = 0x07,
-        ENTITY_EVENT = 0x08,
-        CONNECT_ACCEPT = 0x09,
-        PLAYER_INPUT = 0x03 // Deprecated: use ENTITY_EVENT with INPUT type
+        ENTITY_EVENT = 0x07,
+        CONNECT_ACCEPT = 0x08,
     };
 
     ///
@@ -40,10 +38,8 @@ namespace rnp
     enum class PacketFlags : std::uint16_t
     {
         NONE = 0x0000,
-        ACK_REQ = 0x0001,
-        RELIABLE = 0x0002,
-        FRAG = 0x0004,
-        COMPRESSED = 0x0008
+        RELIABLE = 0x0001,
+        COMPRESSED = 0x0002
     };
 
     ///
@@ -113,12 +109,10 @@ namespace rnp
     ///
     struct PacketHeader
     {
-            std::uint8_t type;       // PacketType
-            std::uint16_t length;    // Payload length in bytes
-            std::uint16_t flags;     // PacketFlags bitfield
-            std::uint16_t reserved;  // Must be 0
-            std::uint32_t sequence;  // Per-session, monotonic sequence number
-            std::uint32_t sessionId; // Server-assigned session ID
+            std::uint8_t type;
+            std::uint16_t length;
+            std::uint16_t flags;
+            std::uint32_t sessionId;
     };
 
     ///
@@ -127,7 +121,7 @@ namespace rnp
     struct PacketConnect
     {
             std::uint8_t nameLen;
-            char playerName[32];
+            std::array<char, 32> playerName;
             std::uint32_t clientCaps;
     };
 
@@ -182,15 +176,6 @@ namespace rnp
     };
 
     ///
-    /// @brief ACK packet payload
-    ///
-    struct PacketAck
-    {
-            std::uint32_t cumulativeAck;
-            std::uint32_t ackBits; // 32-bit SACK window
-    };
-
-    ///
     /// @brief ERROR packet payload
     ///
     struct PacketError
@@ -199,177 +184,5 @@ namespace rnp
             std::uint16_t msgLen;
             std::string description;
     };
-
-    ///
-    /// @brief Fragmentation header (when FRAG flag is set)
-    ///
-    struct FragmentHeader
-    {
-            std::uint16_t fragId;
-            std::uint16_t fragIndex;
-            std::uint16_t fragCount;
-    };
-
-    ///
-    /// @brief Serialize events in ENTITY_EVENT format (TLV with entity_id)
-    /// Format per event: type(1) | entity_id(4, BE) | data_len(1) | data(data_len)
-    ///
-    inline std::vector<std::uint8_t> serializeEvents(const std::vector<EventRecord> &events)
-    {
-        std::vector<std::uint8_t> payload;
-        payload.reserve(64);
-
-        for (const auto &ev : events)
-        {
-            const std::uint8_t dataLen = static_cast<std::uint8_t>(ev.data.size());
-
-            // Event type (1 byte)
-            payload.push_back(static_cast<std::uint8_t>(ev.type));
-
-            // Entity ID (4 bytes, big endian)
-            payload.push_back(static_cast<std::uint8_t>((ev.entityId >> 24) & 0xFF));
-            payload.push_back(static_cast<std::uint8_t>((ev.entityId >> 16) & 0xFF));
-            payload.push_back(static_cast<std::uint8_t>((ev.entityId >> 8) & 0xFF));
-            payload.push_back(static_cast<std::uint8_t>(ev.entityId & 0xFF));
-
-            // Data length (1 byte)
-            payload.push_back(dataLen);
-
-            // Data (dataLen bytes)
-            payload.insert(payload.end(), ev.data.begin(), ev.data.end());
-
-            if (payload.size() > MAX_PAYLOAD)
-            {
-                throw std::runtime_error("Events payload exceeds MAX_PAYLOAD");
-            }
-        }
-        return payload;
-    }
-
-    ///
-    /// @brief Deserialize ENTITY_EVENT payload into event records
-    /// Format per event: type(1) | entity_id(4, BE) | data_len(1) | data(data_len)
-    ///
-    inline std::vector<EventRecord> deserializeEvents(const std::uint8_t *payload, const std::size_t length)
-    {
-        std::vector<EventRecord> events;
-        std::size_t offset = 0;
-
-        while (offset < length)
-        {
-            if (length - offset < 6) // type(1) + entity_id(4) + data_len(1)
-            {
-                throw std::runtime_error("Truncated event header in payload");
-            }
-
-            const EventType type = static_cast<EventType>(payload[offset]);
-            const std::uint32_t entityId = (static_cast<std::uint32_t>(payload[offset + 1]) << 24) |
-                                           (static_cast<std::uint32_t>(payload[offset + 2]) << 16) |
-                                           (static_cast<std::uint32_t>(payload[offset + 3]) << 8) |
-                                           static_cast<std::uint32_t>(payload[offset + 4]);
-            const std::uint8_t dataLen = payload[offset + 5];
-            offset += 6;
-
-            if (length - offset < dataLen)
-            {
-                throw std::runtime_error("Truncated event data in payload");
-            }
-
-            EventRecord rec{type, entityId, {}};
-            if (dataLen > 0)
-            {
-                rec.data.insert(rec.data.end(), payload + offset, payload + offset + dataLen);
-            }
-            events.emplace_back(std::move(rec));
-            offset += dataLen;
-        }
-        return events;
-    }
-
-    ///
-    /// @brief Serialize packet header (Big Endian as per RNP spec)
-    ///
-    inline std::vector<uint8_t> serializeHeader(const PacketHeader &header)
-    {
-        std::vector<uint8_t> buffer(16); // Fixed header size
-
-        buffer[0] = header.type;
-
-        // length (2 bytes, big endian)
-        buffer[1] = static_cast<uint8_t>((header.length >> 8) & 0xFF);
-        buffer[2] = static_cast<uint8_t>(header.length & 0xFF);
-
-        // flags (2 bytes, big endian)
-        buffer[3] = static_cast<uint8_t>((header.flags >> 8) & 0xFF);
-        buffer[4] = static_cast<uint8_t>(header.flags & 0xFF);
-
-        // reserved (2 bytes)
-        buffer[5] = static_cast<uint8_t>((header.reserved >> 8) & 0xFF);
-        buffer[6] = static_cast<uint8_t>(header.reserved & 0xFF);
-
-        // sequence (4 bytes, big endian)
-        buffer[7] = static_cast<uint8_t>((header.sequence >> 24) & 0xFF);
-        buffer[8] = static_cast<uint8_t>((header.sequence >> 16) & 0xFF);
-        buffer[9] = static_cast<uint8_t>((header.sequence >> 8) & 0xFF);
-        buffer[10] = static_cast<uint8_t>(header.sequence & 0xFF);
-
-        // sessionId (4 bytes, big endian)
-        buffer[11] = static_cast<uint8_t>((header.sessionId >> 24) & 0xFF);
-        buffer[12] = static_cast<uint8_t>((header.sessionId >> 16) & 0xFF);
-        buffer[13] = static_cast<uint8_t>((header.sessionId >> 8) & 0xFF);
-        buffer[14] = static_cast<uint8_t>(header.sessionId & 0xFF);
-
-        buffer[15] = 0; // Padding to 16 bytes
-
-        return buffer;
-    }
-
-    ///
-    /// @brief Serialize packet with header and optional payload (Big Endian)
-    ///
-    inline std::vector<uint8_t> serialize(const PacketHeader &header, const uint8_t *payload = nullptr)
-    {
-        std::vector<uint8_t> buffer = serializeHeader(header);
-
-        if (payload && header.length > 0)
-        {
-            buffer.insert(buffer.end(), payload, payload + header.length);
-        }
-
-        return buffer;
-    }
-
-    ///
-    /// @brief Deserialize packet header (Big Endian)
-    ///
-    inline PacketHeader deserializeHeader(const uint8_t *data, const std::size_t size)
-    {
-        if (size < 16)
-        {
-            throw std::runtime_error("Buffer too small for header");
-        }
-
-        PacketHeader header;
-
-        header.type = data[0];
-
-        // length (2 bytes, big endian)
-        header.length = (static_cast<std::uint16_t>(data[1]) << 8) | static_cast<std::uint16_t>(data[2]);
-
-        // flags (2 bytes, big endian)
-        header.flags = (static_cast<std::uint16_t>(data[3]) << 8) | static_cast<std::uint16_t>(data[4]);
-
-        // reserved (2 bytes)
-        header.reserved = (static_cast<std::uint16_t>(data[5]) << 8) | static_cast<std::uint16_t>(data[6]);
-
-        // sequence (4 bytes, big endian)
-        header.sequence = (static_cast<std::uint32_t>(data[7]) << 24) | (static_cast<std::uint32_t>(data[8]) << 16) |
-                          (static_cast<std::uint32_t>(data[9]) << 8) | static_cast<std::uint32_t>(data[10]);
-
-        header.sessionId = (static_cast<std::uint32_t>(data[11]) << 24) | (static_cast<std::uint32_t>(data[12]) << 16) |
-                           (static_cast<std::uint32_t>(data[13]) << 8) | static_cast<std::uint32_t>(data[14]);
-
-        return header;
-    }
 
 } // namespace rnp

--- a/modules/Interfaces/include/Interfaces/Protocol/Serializer.hpp
+++ b/modules/Interfaces/include/Interfaces/Protocol/Serializer.hpp
@@ -1,0 +1,692 @@
+///
+/// @file Serializer.hpp
+/// @brief Network packet serializer for RNP protocol
+/// @namespace rnp
+///
+
+#pragma once
+
+#include "Protocol.hpp"
+#include <algorithm>
+#include <cstring>
+#include <stdexcept>
+#include <vector>
+
+namespace rnp
+{
+
+    ///
+    /// @brief Utility class for endianness conversion
+    ///
+    class EndianUtils
+    {
+        public:
+            static std::uint16_t hostToNetwork16(std::uint16_t hostValue)
+            {
+                return ((hostValue & 0xFF00) >> 8) | ((hostValue & 0x00FF) << 8);
+            }
+
+            static std::uint32_t hostToNetwork32(std::uint32_t hostValue)
+            {
+                return ((hostValue & 0xFF000000) >> 24) | ((hostValue & 0x00FF0000) >> 8) |
+                       ((hostValue & 0x0000FF00) << 8) | ((hostValue & 0x000000FF) << 24);
+            }
+
+            static float hostToNetworkFloat(float hostValue)
+            {
+                std::uint32_t intValue;
+                std::memcpy(&intValue, &hostValue, sizeof(float));
+                intValue = hostToNetwork32(intValue);
+                float result;
+                std::memcpy(&result, &intValue, sizeof(float));
+                return result;
+            }
+
+            static std::uint16_t networkToHost16(std::uint16_t networkValue)
+            {
+                return hostToNetwork16(networkValue); // Same operation for 16-bit
+            }
+
+            static std::uint32_t networkToHost32(std::uint32_t networkValue)
+            {
+                return hostToNetwork32(networkValue); // Same operation for 32-bit
+            }
+
+            static float networkToHostFloat(float networkValue)
+            {
+                return hostToNetworkFloat(networkValue); // Same operation for float
+            }
+    };
+
+    ///
+    /// @brief Binary serializer for RNP protocol packets
+    ///
+    class Serializer
+    {
+        private:
+            std::vector<std::uint8_t> buffer_;
+            std::size_t writePos_;
+            std::size_t readPos_;
+
+        public:
+            ///
+            /// @brief Constructor
+            ///
+            Serializer() : writePos_(0), readPos_(0) { buffer_.reserve(MAX_PAYLOAD + sizeof(PacketHeader)); }
+
+            ///
+            /// @brief Constructor with initial capacity
+            /// @param capacity Initial buffer capacity
+            ///
+            explicit Serializer(std::size_t capacity) : writePos_(0), readPos_(0) { buffer_.reserve(capacity); }
+
+            ///
+            /// @brief Constructor from existing data
+            /// @param data Existing data to deserialize
+            ///
+            explicit Serializer(const std::vector<std::uint8_t> &data)
+                : buffer_(data), writePos_(data.size()), readPos_(0)
+            {
+            }
+
+            ///
+            /// @brief Reset the serializer for reuse
+            ///
+            void reset()
+            {
+                buffer_.clear();
+                writePos_ = 0;
+                readPos_ = 0;
+            }
+
+            ///
+            /// @brief Get the serialized data
+            /// @return Vector containing the serialized bytes
+            ///
+            const std::vector<std::uint8_t> &getData() const { return buffer_; }
+
+            ///
+            /// @brief Get the current size of serialized data
+            /// @return Size in bytes
+            ///
+            std::size_t getSize() const { return writePos_; }
+
+            ///
+            /// @brief Write raw bytes
+            /// @param data Pointer to data
+            /// @param size Number of bytes to write
+            ///
+            void writeBytes(const void *data, std::size_t size)
+            {
+                if (writePos_ + size > MAX_PAYLOAD + sizeof(PacketHeader))
+                {
+                    throw std::runtime_error("Serializer buffer overflow");
+                }
+
+                buffer_.resize(writePos_ + size);
+                std::memcpy(buffer_.data() + writePos_, data, size);
+                writePos_ += size;
+            }
+
+            ///
+            /// @brief Write a single byte
+            /// @param value Byte value to write
+            ///
+            void writeByte(std::uint8_t value) { writeBytes(&value, sizeof(value)); }
+
+            ///
+            /// @brief Write a 16-bit integer (network byte order)
+            /// @param value 16-bit integer to write
+            ///
+            void writeUInt16(std::uint16_t value)
+            {
+                std::uint16_t networkValue = EndianUtils::hostToNetwork16(value);
+                writeBytes(&networkValue, sizeof(networkValue));
+            }
+
+            ///
+            /// @brief Write a 32-bit integer (network byte order)
+            /// @param value 32-bit integer to write
+            ///
+            void writeUInt32(std::uint32_t value)
+            {
+                std::uint32_t networkValue = EndianUtils::hostToNetwork32(value);
+                writeBytes(&networkValue, sizeof(networkValue));
+            }
+
+            ///
+            /// @brief Write a float (network byte order)
+            /// @param value Float to write
+            ///
+            void writeFloat(float value)
+            {
+                float networkValue = EndianUtils::hostToNetworkFloat(value);
+                writeBytes(&networkValue, sizeof(networkValue));
+            }
+
+            ///
+            /// @brief Write a string with length prefix
+            /// @param str String to write
+            /// @param maxLength Maximum allowed length
+            ///
+            void writeString(const std::string &str, std::size_t maxLength)
+            {
+                if (str.length() > maxLength)
+                {
+                    throw std::runtime_error("String too long for serialization");
+                }
+
+                writeByte(static_cast<std::uint8_t>(str.length()));
+                if (!str.empty())
+                {
+                    writeBytes(str.data(), str.length());
+                }
+            }
+
+            ///
+            /// @brief Read raw bytes
+            /// @param data Pointer to destination buffer
+            /// @param size Number of bytes to read
+            ///
+            void readBytes(void *data, std::size_t size)
+            {
+                if (readPos_ + size > buffer_.size())
+                {
+                    throw std::runtime_error("Serializer buffer underflow");
+                }
+
+                std::memcpy(data, buffer_.data() + readPos_, size);
+                readPos_ += size;
+            }
+
+            ///
+            /// @brief Read a single byte
+            /// @return Byte value
+            ///
+            std::uint8_t readByte()
+            {
+                std::uint8_t value;
+                readBytes(&value, sizeof(value));
+                return value;
+            }
+
+            ///
+            /// @brief Read a 16-bit integer (network byte order)
+            /// @return 16-bit integer in host byte order
+            ///
+            std::uint16_t readUInt16()
+            {
+                std::uint16_t networkValue;
+                readBytes(&networkValue, sizeof(networkValue));
+                return EndianUtils::networkToHost16(networkValue);
+            }
+
+            ///
+            /// @brief Read a 32-bit integer (network byte order)
+            /// @return 32-bit integer in host byte order
+            ///
+            std::uint32_t readUInt32()
+            {
+                std::uint32_t networkValue;
+                readBytes(&networkValue, sizeof(networkValue));
+                return EndianUtils::networkToHost32(networkValue);
+            }
+
+            ///
+            /// @brief Read a float (network byte order)
+            /// @return Float in host byte order
+            ///
+            float readFloat()
+            {
+                float networkValue;
+                readBytes(&networkValue, sizeof(networkValue));
+                return EndianUtils::networkToHostFloat(networkValue);
+            }
+
+            ///
+            /// @brief Read a string with length prefix
+            /// @param maxLength Maximum expected length
+            /// @return The read string
+            ///
+            std::string readString(std::size_t maxLength)
+            {
+                std::uint8_t length = readByte();
+                if (length > maxLength)
+                {
+                    throw std::runtime_error("String length exceeds maximum");
+                }
+
+                if (length == 0)
+                {
+                    return std::string();
+                }
+
+                std::string result(length, '\0');
+                readBytes(result.data(), length);
+                return result;
+            }
+
+            ///
+            /// @brief Serialize packet header
+            /// @param header Header to serialize
+            ///
+            void serializeHeader(const PacketHeader &header)
+            {
+                writeByte(header.type);
+                writeUInt16(header.length);
+                writeUInt16(header.flags);
+                writeUInt32(header.sessionId);
+            }
+
+            ///
+            /// @brief Deserialize packet header
+            /// @return Deserialized header
+            ///
+            PacketHeader deserializeHeader()
+            {
+                PacketHeader header;
+                header.type = readByte();
+                header.length = readUInt16();
+                header.flags = readUInt16();
+                header.sessionId = readUInt32();
+                return header;
+            }
+
+            ///
+            /// @brief Serialize CONNECT packet
+            /// @param packet CONNECT packet to serialize
+            ///
+            void serializeConnect(const PacketConnect &packet)
+            {
+                writeByte(packet.nameLen);
+                writeBytes(packet.playerName.data(), packet.playerName.size());
+                writeUInt32(packet.clientCaps);
+            }
+
+            ///
+            /// @brief Deserialize CONNECT packet
+            /// @return Deserialized CONNECT packet
+            ///
+            PacketConnect deserializeConnect()
+            {
+                PacketConnect packet;
+                packet.nameLen = readByte();
+                readBytes(packet.playerName.data(), packet.playerName.size());
+                packet.clientCaps = readUInt32();
+                return packet;
+            }
+
+            ///
+            /// @brief Serialize CONNECT_ACCEPT packet
+            /// @param packet CONNECT_ACCEPT packet to serialize
+            ///
+            void serializeConnectAccept(const PacketConnectAccept &packet)
+            {
+                writeUInt32(packet.sessionId);
+                writeUInt16(packet.tickRateHz);
+                writeUInt16(packet.mtuPayloadBytes);
+                writeUInt32(packet.serverCaps);
+            }
+
+            ///
+            /// @brief Deserialize CONNECT_ACCEPT packet
+            /// @return Deserialized CONNECT_ACCEPT packet
+            ///
+            PacketConnectAccept deserializeConnectAccept()
+            {
+                PacketConnectAccept packet;
+                packet.sessionId = readUInt32();
+                packet.tickRateHz = readUInt16();
+                packet.mtuPayloadBytes = readUInt16();
+                packet.serverCaps = readUInt32();
+                return packet;
+            }
+
+            ///
+            /// @brief Serialize DISCONNECT packet
+            /// @param packet DISCONNECT packet to serialize
+            ///
+            void serializeDisconnect(const PacketDisconnect &packet) { writeUInt16(packet.reasonCode); }
+
+            ///
+            /// @brief Deserialize DISCONNECT packet
+            /// @return Deserialized DISCONNECT packet
+            ///
+            PacketDisconnect deserializeDisconnect()
+            {
+                PacketDisconnect packet;
+                packet.reasonCode = readUInt16();
+                return packet;
+            }
+
+            ///
+            /// @brief Serialize EntityState
+            /// @param entity Entity state to serialize
+            ///
+            void serializeEntityState(const EntityState &entity)
+            {
+                writeUInt32(entity.id);
+                writeUInt16(entity.type);
+                writeFloat(entity.x);
+                writeFloat(entity.y);
+                writeFloat(entity.vx);
+                writeFloat(entity.vy);
+                writeByte(entity.stateFlags);
+            }
+
+            ///
+            /// @brief Deserialize EntityState
+            /// @return Deserialized entity state
+            ///
+            EntityState deserializeEntityState()
+            {
+                EntityState entity;
+                entity.id = readUInt32();
+                entity.type = readUInt16();
+                entity.x = readFloat();
+                entity.y = readFloat();
+                entity.vx = readFloat();
+                entity.vy = readFloat();
+                entity.stateFlags = readByte();
+                return entity;
+            }
+
+            ///
+            /// @brief Serialize WORLD_STATE packet
+            /// @param packet WORLD_STATE packet to serialize
+            ///
+            void serializeWorldState(const PacketWorldState &packet)
+            {
+                writeUInt32(packet.serverTick);
+                writeUInt16(packet.entityCount);
+
+                for (const auto &entity : packet.entities)
+                {
+                    serializeEntityState(entity);
+                }
+            }
+
+            ///
+            /// @brief Deserialize WORLD_STATE packet
+            /// @return Deserialized WORLD_STATE packet
+            ///
+            PacketWorldState deserializeWorldState()
+            {
+                PacketWorldState packet;
+                packet.serverTick = readUInt32();
+                packet.entityCount = readUInt16();
+
+                packet.entities.reserve(packet.entityCount);
+                for (std::uint16_t i = 0; i < packet.entityCount; ++i)
+                {
+                    packet.entities.push_back(deserializeEntityState());
+                }
+
+                return packet;
+            }
+
+            ///
+            /// @brief Serialize PING/PONG packet
+            /// @param packet PING/PONG packet to serialize
+            ///
+            void serializePingPong(const PacketPingPong &packet)
+            {
+                writeUInt32(packet.nonce);
+                writeUInt32(packet.sendTimeMs);
+            }
+
+            ///
+            /// @brief Deserialize PING/PONG packet
+            /// @return Deserialized PING/PONG packet
+            ///
+            PacketPingPong deserializePingPong()
+            {
+                PacketPingPong packet;
+                packet.nonce = readUInt32();
+                packet.sendTimeMs = readUInt32();
+                return packet;
+            }
+
+            ///
+            /// @brief Serialize ERROR packet
+            /// @param packet ERROR packet to serialize
+            ///
+            void serializeError(const PacketError &packet)
+            {
+                writeUInt16(packet.errorCode);
+                writeUInt16(packet.msgLen);
+                if (!packet.description.empty())
+                {
+                    writeBytes(packet.description.data(), packet.description.length());
+                }
+            }
+
+            ///
+            /// @brief Deserialize ERROR packet
+            /// @return Deserialized ERROR packet
+            ///
+            PacketError deserializeError()
+            {
+                PacketError packet;
+                packet.errorCode = readUInt16();
+                packet.msgLen = readUInt16();
+
+                if (packet.msgLen > 0)
+                {
+                    packet.description.resize(packet.msgLen);
+                    readBytes(packet.description.data(), packet.msgLen);
+                }
+
+                return packet;
+            }
+
+            ///
+            /// @brief Serialize EventRecord for ENTITY_EVENT packets
+            /// @param event Event record to serialize
+            ///
+            void serializeEventRecord(const EventRecord &event)
+            {
+                writeByte(static_cast<std::uint8_t>(event.type));
+                writeUInt32(event.entityId);
+                writeUInt16(static_cast<std::uint16_t>(event.data.size()));
+
+                if (!event.data.empty())
+                {
+                    writeBytes(event.data.data(), event.data.size());
+                }
+            }
+
+            ///
+            /// @brief Deserialize EventRecord from ENTITY_EVENT packets
+            /// @return Deserialized event record
+            ///
+            EventRecord deserializeEventRecord()
+            {
+                EventRecord event;
+                event.type = static_cast<EventType>(readByte());
+                event.entityId = readUInt32();
+
+                std::uint16_t dataLength = readUInt16();
+                if (dataLength > 0)
+                {
+                    event.data.resize(dataLength);
+                    readBytes(event.data.data(), dataLength);
+                }
+
+                return event;
+            }
+
+            ///
+            /// @brief Serialize multiple EventRecords for ENTITY_EVENT packet
+            /// @param events Vector of event records to serialize
+            ///
+            void serializeEntityEvents(const std::vector<EventRecord> &events)
+            {
+                for (const auto &event : events)
+                {
+                    serializeEventRecord(event);
+                }
+            }
+
+            ///
+            /// @brief Deserialize multiple EventRecords from ENTITY_EVENT packet
+            /// @param payloadSize Total size of the payload to deserialize
+            /// @return Vector of deserialized event records
+            ///
+            std::vector<EventRecord> deserializeEntityEvents(std::size_t payloadSize)
+            {
+                std::vector<EventRecord> events;
+                std::size_t bytesRead = 0;
+
+                while (bytesRead < payloadSize && readPos_ < buffer_.size())
+                {
+                    std::size_t startPos = readPos_;
+                    EventRecord event = deserializeEventRecord();
+                    bytesRead += (readPos_ - startPos);
+                    events.push_back(event);
+                }
+
+                return events;
+            }
+
+            ///
+            /// @brief Serialize input data for INPUT events
+            /// @param keys Keyboard input bitmask
+            /// @param mouseX Mouse X position
+            /// @param mouseY Mouse Y position
+            /// @param mouseButtons Mouse button bitmask
+            /// @param timestamp Input timestamp
+            ///
+            void serializeInputData(std::uint8_t keys, float mouseX, float mouseY, std::uint8_t mouseButtons,
+                                    std::uint32_t timestamp)
+            {
+                writeByte(keys);
+                writeFloat(mouseX);
+                writeFloat(mouseY);
+                writeByte(mouseButtons);
+                writeUInt32(timestamp);
+            }
+
+            ///
+            /// @brief Deserialize input data from INPUT events
+            /// @param keys Output keyboard input bitmask
+            /// @param mouseX Output mouse X position
+            /// @param mouseY Output mouse Y position
+            /// @param mouseButtons Output mouse button bitmask
+            /// @param timestamp Output input timestamp
+            ///
+            void deserializeInputData(std::uint8_t &keys, float &mouseX, float &mouseY, std::uint8_t &mouseButtons,
+                                      std::uint32_t &timestamp)
+            {
+                keys = readByte();
+                mouseX = readFloat();
+                mouseY = readFloat();
+                mouseButtons = readByte();
+                timestamp = readUInt32();
+            }
+
+            ///
+            /// @brief Create an EventRecord for input data
+            /// @param entityId Player entity ID
+            /// @param keys Keyboard input
+            /// @param mouseX Mouse X
+            /// @param mouseY Mouse Y
+            /// @param mouseButtons Mouse buttons
+            /// @param timestamp Timestamp
+            /// @return EventRecord ready to send
+            ///
+            static EventRecord createInputEvent(std::uint32_t entityId, std::uint8_t keys, float mouseX, float mouseY,
+                                                std::uint8_t mouseButtons, std::uint32_t timestamp)
+            {
+                Serializer inputSerializer;
+                inputSerializer.serializeInputData(keys, mouseX, mouseY, mouseButtons, timestamp);
+
+                EventRecord event;
+                event.type = EventType::INPUT;
+                event.entityId = entityId;
+                event.data = inputSerializer.getData();
+
+                return event;
+            }
+
+            ///
+            /// @brief Create an EventRecord for spawn event
+            /// @param entityId Entity ID to spawn
+            /// @param entityType Type of entity
+            /// @param x X position
+            /// @param y Y position
+            /// @return EventRecord for spawn
+            ///
+            static EventRecord createSpawnEvent(std::uint32_t entityId, EntityType entityType, float x, float y)
+            {
+                Serializer spawnSerializer;
+                spawnSerializer.writeUInt16(static_cast<std::uint16_t>(entityType));
+                spawnSerializer.writeFloat(x);
+                spawnSerializer.writeFloat(y);
+
+                EventRecord event;
+                event.type = EventType::SPAWN;
+                event.entityId = entityId;
+                event.data = spawnSerializer.getData();
+
+                return event;
+            }
+
+            ///
+            /// @brief Create an EventRecord for damage event
+            /// @param entityId Entity taking damage
+            /// @param damage Amount of damage
+            /// @param sourceId Source entity causing damage
+            /// @return EventRecord for damage
+            ///
+            static EventRecord createDamageEvent(std::uint32_t entityId, std::uint32_t damage,
+                                                 std::uint32_t sourceId = 0)
+            {
+                Serializer damageSerializer;
+                damageSerializer.writeUInt32(damage);
+                damageSerializer.writeUInt32(sourceId);
+
+                EventRecord event;
+                event.type = EventType::DAMAGE;
+                event.entityId = entityId;
+                event.data = damageSerializer.getData();
+
+                return event;
+            }
+
+            ///
+            /// @brief Create an EventRecord for score event
+            /// @param entityId Entity gaining score
+            /// @param score Score amount
+            /// @return EventRecord for score
+            ///
+            static EventRecord createScoreEvent(std::uint32_t entityId, std::uint32_t score)
+            {
+                Serializer scoreSerializer;
+                scoreSerializer.writeUInt32(score);
+
+                EventRecord event;
+                event.type = EventType::SCORE;
+                event.entityId = entityId;
+                event.data = scoreSerializer.getData();
+
+                return event;
+            }
+
+            ///
+            /// @brief Create an EventRecord for despawn event
+            /// @param entityId Entity to despawn
+            /// @return EventRecord for despawn
+            ///
+            static EventRecord createDespawnEvent(std::uint32_t entityId)
+            {
+                EventRecord event;
+                event.type = EventType::DESPAWN;
+                event.entityId = entityId;
+                // Despawn events don't need additional data
+
+                return event;
+            }
+    };
+
+} // namespace rnp

--- a/plugins/Network/Asio/Client/CMakeLists.txt
+++ b/plugins/Network/Asio/Client/CMakeLists.txt
@@ -15,6 +15,7 @@ target_include_directories(${PROJECT_NAME} PRIVATE
         "${CMAKE_SOURCE_DIR}/modules/Interfaces/include"
         "${CMAKE_SOURCE_DIR}/modules/Utils/include"
         "${CMAKE_SOURCE_DIR}/third-party/asio/asio/include"
+        "${CMAKE_SOURCE_DIR}/plugins/Network/Protocol/include"
 )
 target_compile_options(${PROJECT_NAME} PRIVATE ${WARNING_FLAGS})
 target_link_libraries(${PROJECT_NAME} PRIVATE utils)

--- a/plugins/Network/Asio/Client/include/AsioClient/AsioClient.hpp
+++ b/plugins/Network/Asio/Client/include/AsioClient/AsioClient.hpp
@@ -1,99 +1,258 @@
 ///
 /// @file AsioClient.hpp
-/// @brief This file contains the client network implementation for Asio
+/// @brief Asio-based implementation of INetworkClient interface
 /// @namespace eng
 ///
 
 #pragma once
 
-#include <functional>
+#include "Interfaces/INetworkClient.hpp"
+#include "Interfaces/Protocol/HandlerPacket.hpp"
+#include "Interfaces/Protocol/Protocol.hpp"
+#include "Interfaces/Protocol/Serializer.hpp"
+
+#include <asio.hpp>
+#include <atomic>
+#include <chrono>
 #include <memory>
-#include <optional>
+#include <mutex>
+#include <queue>
 #include <string>
 #include <thread>
 #include <vector>
-
-#define ASIO_STANDALONE
-#include "asio.hpp"
-
-#include "Interfaces/INetworkClient.hpp"
-#include "Interfaces/Protocol/Protocol.hpp"
 
 namespace eng
 {
 
     ///
+    /// @brief Queued packet for sending
+    ///
+    struct QueuedPacket
+    {
+            std::vector<std::uint8_t> data;
+            bool reliable;
+
+            QueuedPacket(const std::vector<std::uint8_t> &d, bool rel = false) : data(d), reliable(rel) {}
+    };
+
+    ///
+    /// @brief Connection statistics
+    ///
+    struct ConnectionStats
+    {
+            std::uint32_t packetsSent = 0;
+            std::uint32_t packetsReceived = 0;
+            std::uint32_t bytesTransferred = 0;
+            std::uint32_t packetsLost = 0;
+            std::chrono::steady_clock::time_point connectionTime;
+    };
+
+    ///
     /// @class AsioClient
-    /// @brief Network implementation with asio for client
+    /// @brief Asio UDP client implementation
     /// @namespace eng
     ///
-    class AsioClient final : public INetworkClient
+    class AsioClient : public INetworkClient
     {
+        private:
+            // Network components
+            std::unique_ptr<asio::io_context> m_ioContext;
+            std::unique_ptr<asio::ip::udp::socket> m_socket;
+            std::unique_ptr<std::thread> m_networkThread;
+
+            // Server connection info
+            std::string m_serverHost;
+            std::uint16_t m_serverPort;
+            asio::ip::udp::endpoint m_serverEndpoint;
+
+            // Connection state
+            std::atomic<ConnectionState> m_connectionState;
+            std::uint32_t m_sessionId;
+            std::uint16_t m_serverTickRate;
+            std::uint32_t m_clientCaps;
+
+            // Client configuration
+            std::string m_playerName;
+
+            // Network state
+            std::atomic<bool> m_running;
+
+            // Packet handling
+            std::unique_ptr<rnp::HandlerPacket> m_packetHandler;
+            std::queue<QueuedPacket> m_sendQueue;
+            std::mutex m_sendQueueMutex;
+
+            // Reception buffer
+            std::array<std::uint8_t, 1024> m_recvBuffer;
+            asio::ip::udp::endpoint m_senderEndpoint;
+
+            // Ping/Latency management
+            std::uint32_t m_lastPingNonce;
+            std::chrono::steady_clock::time_point m_lastPingTime;
+            std::uint32_t m_latency; // in milliseconds
+            std::chrono::milliseconds m_pingInterval;
+
+            // Connection timeout
+            std::chrono::steady_clock::time_point m_lastServerResponse;
+            std::chrono::milliseconds m_connectionTimeout;
+
+            // Statistics
+            ConnectionStats m_stats;
+
+            ///
+            /// @brief Initialize packet handlers
+            ///
+            void setupPacketHandlers();
+
+            ///
+            /// @brief Start receiving packets asynchronously
+            ///
+            void startReceive();
+
+            ///
+            /// @brief Handle received packet
+            /// @param bytesReceived Number of bytes received
+            ///
+            void handleReceive(std::size_t bytesReceived);
+
+            ///
+            /// @brief Network thread main loop
+            ///
+            void networkThreadLoop();
+
+            ///
+            /// @brief Send packet immediately
+            /// @param data Packet data
+            ///
+            void sendPacketImmediate(const std::vector<std::uint8_t> &data);
+
+            ///
+            /// @brief Handle CONNECT_ACCEPT packet
+            /// @param packet Connect accept packet
+            /// @param context Packet context
+            /// @return Handler result
+            ///
+            rnp::HandlerResult handleConnectAccept(const rnp::PacketConnectAccept &packet,
+                                                   const rnp::PacketContext &context);
+
+            ///
+            /// @brief Handle DISCONNECT packet
+            /// @param packet Disconnect packet
+            /// @param context Packet context
+            /// @return Handler result
+            ///
+            rnp::HandlerResult handleDisconnect(const rnp::PacketDisconnect &packet, const rnp::PacketContext &context);
+
+            ///
+            /// @brief Handle PONG packet
+            /// @param packet Pong packet
+            /// @param context Packet context
+            /// @return Handler result
+            ///
+            rnp::HandlerResult handlePong(const rnp::PacketPingPong &packet, const rnp::PacketContext &context);
+
+            ///
+            /// @brief Handle PING packet
+            /// @param packet Ping packet
+            /// @param context Packet context
+            /// @return Handler result
+            ///
+            rnp::HandlerResult handlePing(const rnp::PacketPingPong &packet, const rnp::PacketContext &context);
+
+            ///
+            /// @brief Handle ERROR packet
+            /// @param packet Error packet
+            /// @param context Packet context
+            /// @return Handler result
+            ///
+            rnp::HandlerResult handleError(const rnp::PacketError &packet, const rnp::PacketContext &context);
+
+            ///
+            /// @brief Handle WORLD_STATE packet
+            /// @param packet World state packet
+            /// @param context Packet context
+            /// @return Handler result
+            ///
+            rnp::HandlerResult handleWorldState(const rnp::PacketWorldState &packet, const rnp::PacketContext &context);
+
+            ///
+            /// @brief Send CONNECT packet
+            ///
+            void sendConnect();
+
+            ///
+            /// @brief Send DISCONNECT packet
+            ///
+            void sendDisconnect();
+
+            ///
+            /// @brief Send PING packet
+            ///
+            void sendPing();
+
+            ///
+            /// @brief Send PONG response
+            /// @param nonce Ping nonce to echo back
+            ///
+            void sendPong(std::uint32_t nonce);
+
+            ///
+            /// @brief Process send queue
+            ///
+            void processSendQueue();
+
+            ///
+            /// @brief Update connection management (timeouts, pings)
+            ///
+            void updateConnectionManagement();
+
+            ///
+            /// @brief Generate ping nonce
+            /// @return New ping nonce
+            ///
+            std::uint32_t generatePingNonce();
+
         public:
-            using PacketHandler = std::function<void(const rnp::PacketHeader &, const std::vector<uint8_t> &)>;
-
+            ///
+            /// @brief Constructor
+            ///
             AsioClient();
-            ~AsioClient() override = default;
 
-            AsioClient(const AsioClient &) = delete;
-            AsioClient(AsioClient &&) = delete;
-            AsioClient &operator=(const AsioClient &) = delete;
-            AsioClient &operator=(AsioClient &&) = delete;
+            ///
+            /// @brief Destructor
+            ///
+            ~AsioClient() override;
 
-            [[nodiscard]] const std::string getName() const override { return "Network_Asio_Client"; }
-            [[nodiscard]] utl::PluginType getType() const override { return utl::PluginType::NETWORK_CLIENT; }
-
-            void connect(const std::string &host, uint16_t port) override;
+            // INetworkClient implementation
+            void connect(const std::string &host, std::uint16_t port) override;
             void disconnect() override;
 
-            void sendConnect(const std::string &playerName);
-            void sendConnectWithCaps(const std::string &playerName, std::uint32_t clientCaps);
-            void sendDisconnect();
-            void sendDisconnect(rnp::DisconnectReason reason);
-            void sendPlayerInput(uint8_t direction, uint8_t shooting);
-            void sendPlayerInputAsEvent(std::uint16_t playerId, uint8_t direction, uint8_t shooting,
-                                        uint32_t clientTimeMs);
-            void sendPing();
-            void sendPing(std::uint32_t nonce, std::uint32_t sendTimeMs);
-            void sendAck(std::uint32_t cumulative, std::uint32_t ackBits);
+            void update() override;
 
-            void setPacketHandler(rnp::PacketType type, PacketHandler handler);
+            [[nodiscard]] const std::string getName() const override { return "Network_Client"; }
+            [[nodiscard]] utl::PluginType getType() const override { return utl::PluginType::NETWORK_CLIENT; }
 
-            void setEventsHandler(std::function<void(const std::vector<rnp::EventRecord> &)> handler);
+            [[nodiscard]] bool isConnected() const override;
+            [[nodiscard]] ConnectionState getConnectionState() const override;
+            [[nodiscard]] std::uint32_t getSessionId() const override;
+            [[nodiscard]] std::uint16_t getServerTickRate() const override;
+            [[nodiscard]] std::uint32_t getLatency() const override;
 
-            std::uint32_t getSessionId() const { return m_sessionId; }
-            std::uint16_t getServerTickRate() const { return m_serverTickRate; }
+            void setPlayerName(const std::string &playerName) override;
+            void setClientCapabilities(std::uint32_t caps) override;
 
-        private:
-            void startReceive();
-            void handleReceive(const asio::error_code &error, std::size_t bytesTransferred);
-            void handleSend(const asio::error_code &error, std::size_t bytesTransferred);
-            void processPacket(const std::vector<uint8_t> &data);
-            void processEvents(const std::vector<uint8_t> &payload);
-            void handleConnectAccept(const std::vector<uint8_t> &payload);
-            void handleReliablePacket(const rnp::PacketHeader &header);
-            void processAck(const std::vector<uint8_t> &payload);
-            void processWorldState(const std::vector<uint8_t> &payload);
-            void processEntityEvent(const std::vector<uint8_t> &payload);
-            void retransmitReliable();
+            ///
+            /// @brief Send custom packet to server
+            /// @param data Packet data
+            /// @param reliable Whether packet should be reliable
+            ///
+            void sendToServer(const std::vector<std::uint8_t> &data, bool reliable = false);
 
-            asio::io_context m_ioContext;
-            asio::ip::udp::socket m_socket;
-            asio::ip::udp::endpoint m_serverEndpoint;
-            std::array<uint8_t, rnp::MAX_PAYLOAD + 16> m_recvBuffer;
+            ///
+            /// @brief Get connection statistics
+            /// @return Current connection stats
+            ///
+            const ConnectionStats &getStats() const { return m_stats; }
+    };
 
-            std::unique_ptr<asio::executor_work_guard<asio::io_context::executor_type>> m_workGuard;
-            std::thread m_ioThread;
-            std::unordered_map<rnp::PacketType, PacketHandler> m_packetHandlers;
-            std::function<void(const std::vector<rnp::EventRecord> &)> m_eventsHandler;
-            uint32_t m_sequenceNumber = 0;
-            bool m_connected = false;
-            std::uint32_t m_sessionId = 0;
-            std::uint16_t m_serverTickRate = 0;
-            std::uint16_t m_serverMtu = 0;
-            std::uint32_t m_serverCaps = 0;
-            std::uint32_t m_clientCaps = 0;
-            std::unordered_map<std::uint32_t, std::vector<uint8_t>> m_pendingReliable;
-            std::uint32_t m_lastAckSent = 0;
-    }; // class AsioClient
 } // namespace eng

--- a/plugins/Network/Asio/Client/src/asioClient.cpp
+++ b/plugins/Network/Asio/Client/src/asioClient.cpp
@@ -1,548 +1,592 @@
-#include <cstring>
-#include <iostream>
-
-#include <asio.hpp>
+///
+/// @file AsioClient.cpp
+/// @brief Asio-based implementation of INetworkClient interface
+/// @namespace eng
+///
 
 #include "AsioClient/AsioClient.hpp"
+#include "Utils/Logger.hpp"
 
-using asio::ip::udp;
+#include <chrono>
+#include <iostream>
+#include <random>
 
-eng::AsioClient::AsioClient() : m_socket(m_ioContext) {}
-
-void eng::AsioClient::connect(const std::string &host, uint16_t port)
+namespace eng
 {
-    try
+
+    AsioClient::AsioClient()
+        : m_ioContext(std::make_unique<asio::io_context>()),
+          m_socket(std::make_unique<asio::ip::udp::socket>(*m_ioContext)), m_serverPort(0),
+          m_connectionState(ConnectionState::DISCONNECTED), m_sessionId(0), m_serverTickRate(60), m_clientCaps(0),
+          m_running(false), m_packetHandler(std::make_unique<rnp::HandlerPacket>()), m_lastPingNonce(0), m_latency(0),
+          m_pingInterval(std::chrono::seconds(5)), m_connectionTimeout(std::chrono::seconds(30))
     {
-        const asio::ip::address addr = asio::ip::make_address(host);
-        m_serverEndpoint = udp::endpoint(addr, port);
-
-        m_socket.open(udp::v4());
-
-        m_workGuard = std::make_unique<asio::executor_work_guard<asio::io_context::executor_type>>(
-            asio::make_work_guard(m_ioContext));
-        m_ioThread = std::thread(
-            [this]()
-            {
-                try
-                {
-                    m_ioContext.run();
-                }
-                catch (const std::exception &e)
-                {
-                    std::cerr << "[AsioClient] IO context exception: " << e.what() << "\n";
-                }
-            });
-
-        startReceive();
+        m_stats.connectionTime = std::chrono::steady_clock::now();
+        setupPacketHandlers();
+        utl::Logger::log("AsioClient: Initialized", utl::LogLevel::INFO);
     }
-    catch (const std::exception &e)
+
+    AsioClient::~AsioClient()
     {
-        std::cerr << "[AsioClient] Erreur de connexion: " << e.what() << "\n";
+        disconnect();
+        utl::Logger::log("AsioClient: Destroyed", utl::LogLevel::INFO);
     }
-}
 
-void eng::AsioClient::disconnect()
-{
-    if (m_connected)
+    void AsioClient::connect(const std::string &host, std::uint16_t port)
     {
-        sendDisconnect();
-
-        if (m_workGuard)
+        if (m_connectionState.load() != ConnectionState::DISCONNECTED)
         {
-            asio::post(m_ioContext,
-                       [this]()
-                       {
-                           asio::error_code ec;
-                           m_socket.close(ec);
-                       });
-            m_workGuard.reset();
-        }
-
-        m_ioContext.stop();
-
-        if (m_ioThread.joinable())
-        {
-            m_ioThread.join();
-        }
-
-        m_connected = false;
-        std::cout << "[AsioClient] Déconnecté du serveur\n";
-    }
-}
-
-void eng::AsioClient::sendConnect(const std::string &playerName) { sendConnectWithCaps(playerName, 0); }
-
-void eng::AsioClient::sendConnectWithCaps(const std::string &playerName, std::uint32_t clientCaps)
-{
-    rnp::PacketHeader header;
-    header.type = static_cast<std::uint8_t>(rnp::PacketType::CONNECT);
-
-    // Payload: name_len(1) | player_name[name_len] | client_caps(4, BE)
-    std::vector<uint8_t> payload;
-    std::uint8_t nameLen = std::min(static_cast<std::uint8_t>(playerName.size()), static_cast<std::uint8_t>(31));
-    payload.push_back(nameLen);
-    payload.insert(payload.end(), playerName.begin(), playerName.begin() + nameLen);
-
-    // client_caps (4 bytes, big endian)
-    payload.push_back(static_cast<uint8_t>((clientCaps >> 24) & 0xFF));
-    payload.push_back(static_cast<uint8_t>((clientCaps >> 16) & 0xFF));
-    payload.push_back(static_cast<uint8_t>((clientCaps >> 8) & 0xFF));
-    payload.push_back(static_cast<uint8_t>(clientCaps & 0xFF));
-
-    header.length = payload.size();
-    header.flags =
-        static_cast<std::uint16_t>(rnp::PacketFlags::RELIABLE) | static_cast<std::uint16_t>(rnp::PacketFlags::ACK_REQ);
-    header.reserved = 0;
-    header.sequence = ++m_sequenceNumber;
-    header.sessionId = 0; // Pas encore de session
-
-    m_clientCaps = clientCaps;
-    std::vector<uint8_t> buffer = rnp::serialize(header, payload.data());
-
-    m_socket.async_send_to(asio::buffer(buffer), m_serverEndpoint,
-                           [this](const asio::error_code &error, std::size_t bytesTransferred)
-                           { handleSend(error, bytesTransferred); });
-}
-
-void eng::AsioClient::sendDisconnect() { sendDisconnect(rnp::DisconnectReason::CLIENT_REQUEST); }
-
-void eng::AsioClient::sendDisconnect(rnp::DisconnectReason reason)
-{
-    rnp::PacketHeader header;
-    header.type = static_cast<std::uint8_t>(rnp::PacketType::DISCONNECT);
-
-    // Payload: reason_code(2, BE)
-    std::vector<uint8_t> payload;
-    std::uint16_t reasonCode = static_cast<std::uint16_t>(reason);
-    payload.push_back(static_cast<uint8_t>((reasonCode >> 8) & 0xFF));
-    payload.push_back(static_cast<uint8_t>(reasonCode & 0xFF));
-
-    header.length = payload.size();
-    header.flags = 0;
-    header.reserved = 0;
-    header.sequence = ++m_sequenceNumber;
-    header.sessionId = m_sessionId;
-
-    std::vector<uint8_t> buffer = rnp::serialize(header, payload.data());
-
-    m_socket.async_send_to(asio::buffer(buffer), m_serverEndpoint,
-                           [this](const asio::error_code &error, std::size_t bytesTransferred)
-                           { handleSend(error, bytesTransferred); });
-}
-
-void eng::AsioClient::sendPlayerInput(uint8_t direction, uint8_t shooting)
-{
-    rnp::PacketHeader header;
-    header.type = static_cast<std::uint8_t>(rnp::PacketType::PLAYER_INPUT);
-    header.length = 2;
-    header.flags = 0;
-    header.reserved = 0;
-    header.sequence = ++m_sequenceNumber;
-    header.sessionId = m_sessionId;
-
-    uint8_t payload[2] = {direction, shooting};
-    std::vector<uint8_t> buffer = rnp::serialize(header, payload);
-
-    m_socket.async_send_to(asio::buffer(buffer), m_serverEndpoint,
-                           [this](const asio::error_code &error, std::size_t bytesTransferred)
-                           { handleSend(error, bytesTransferred); });
-}
-
-void eng::AsioClient::sendPlayerInputAsEvent(std::uint16_t playerId, uint8_t direction, uint8_t shooting,
-                                             uint32_t clientTimeMs)
-{
-    rnp::EventRecord ev;
-    ev.type = rnp::EventType::INPUT;
-    ev.entityId = playerId;
-
-    // Data: buttons(2, BE) | direction(1) | shooting(1) | client_time_ms(4, BE)
-    std::uint16_t buttons = 0; // TODO: map from direction/shooting to buttons
-    ev.data.push_back(static_cast<uint8_t>((buttons >> 8) & 0xFF));
-    ev.data.push_back(static_cast<uint8_t>(buttons & 0xFF));
-    ev.data.push_back(direction);
-    ev.data.push_back(shooting);
-    ev.data.push_back(static_cast<uint8_t>((clientTimeMs >> 24) & 0xFF));
-    ev.data.push_back(static_cast<uint8_t>((clientTimeMs >> 16) & 0xFF));
-    ev.data.push_back(static_cast<uint8_t>((clientTimeMs >> 8) & 0xFF));
-    ev.data.push_back(static_cast<uint8_t>(clientTimeMs & 0xFF));
-
-    std::vector<rnp::EventRecord> events;
-    events.push_back(ev);
-
-    const std::vector<uint8_t> eventsPayload = rnp::serializeEvents(events);
-
-    rnp::PacketHeader header;
-    header.type = static_cast<std::uint8_t>(rnp::PacketType::ENTITY_EVENT);
-    header.length = static_cast<std::uint16_t>(eventsPayload.size());
-    header.flags = 0;
-    header.reserved = 0;
-    header.sequence = ++m_sequenceNumber;
-    header.sessionId = m_sessionId;
-
-    std::vector<uint8_t> buffer = rnp::serialize(header, eventsPayload.data());
-
-    m_socket.async_send_to(asio::buffer(buffer), m_serverEndpoint,
-                           [this](const asio::error_code &error, std::size_t bytesTransferred)
-                           { handleSend(error, bytesTransferred); });
-}
-
-void eng::AsioClient::sendPing()
-{
-    rnp::PacketHeader header;
-    header.type = static_cast<std::uint8_t>(rnp::PacketType::PING);
-    header.length = 0;
-    header.flags = 0;
-    header.reserved = 0;
-    header.sequence = ++m_sequenceNumber;
-    header.sessionId = m_sessionId;
-
-    std::vector<uint8_t> buffer = rnp::serialize(header);
-
-    m_socket.async_send_to(asio::buffer(buffer), m_serverEndpoint,
-                           [this](const asio::error_code &error, std::size_t bytesTransferred)
-                           { handleSend(error, bytesTransferred); });
-}
-
-void eng::AsioClient::sendPing(std::uint32_t nonce, std::uint32_t sendTimeMs)
-{
-    rnp::PacketHeader header;
-    header.type = static_cast<std::uint8_t>(rnp::PacketType::PING);
-
-    // Payload: nonce(4, BE) | send_time_ms(4, BE)
-    std::vector<uint8_t> payload;
-
-    // nonce (4 bytes, big endian)
-    payload.push_back(static_cast<uint8_t>((nonce >> 24) & 0xFF));
-    payload.push_back(static_cast<uint8_t>((nonce >> 16) & 0xFF));
-    payload.push_back(static_cast<uint8_t>((nonce >> 8) & 0xFF));
-    payload.push_back(static_cast<uint8_t>(nonce & 0xFF));
-
-    // send_time_ms (4 bytes, big endian)
-    payload.push_back(static_cast<uint8_t>((sendTimeMs >> 24) & 0xFF));
-    payload.push_back(static_cast<uint8_t>((sendTimeMs >> 16) & 0xFF));
-    payload.push_back(static_cast<uint8_t>((sendTimeMs >> 8) & 0xFF));
-    payload.push_back(static_cast<uint8_t>(sendTimeMs & 0xFF));
-
-    header.length = payload.size();
-    header.flags = 0;
-    header.reserved = 0;
-    header.sequence = ++m_sequenceNumber;
-    header.sessionId = m_sessionId;
-
-    std::vector<uint8_t> buffer = rnp::serialize(header, payload.data());
-
-    m_socket.async_send_to(asio::buffer(buffer), m_serverEndpoint,
-                           [this](const asio::error_code &error, std::size_t bytesTransferred)
-                           { handleSend(error, bytesTransferred); });
-}
-
-void eng::AsioClient::sendAck(std::uint32_t cumulative, std::uint32_t ackBits)
-{
-    rnp::PacketHeader header;
-    header.type = static_cast<std::uint8_t>(rnp::PacketType::ACK);
-
-    // Payload: cumulative_ack(4, BE) | ack_bits(4, BE)
-    std::vector<uint8_t> payload;
-
-    // cumulative_ack (4 bytes, big endian)
-    payload.push_back(static_cast<uint8_t>((cumulative >> 24) & 0xFF));
-    payload.push_back(static_cast<uint8_t>((cumulative >> 16) & 0xFF));
-    payload.push_back(static_cast<uint8_t>((cumulative >> 8) & 0xFF));
-    payload.push_back(static_cast<uint8_t>(cumulative & 0xFF));
-
-    // ack_bits (4 bytes, big endian)
-    payload.push_back(static_cast<uint8_t>((ackBits >> 24) & 0xFF));
-    payload.push_back(static_cast<uint8_t>((ackBits >> 16) & 0xFF));
-    payload.push_back(static_cast<uint8_t>((ackBits >> 8) & 0xFF));
-    payload.push_back(static_cast<uint8_t>(ackBits & 0xFF));
-
-    header.length = payload.size();
-    header.flags = 0;
-    header.reserved = 0;
-    header.sequence = ++m_sequenceNumber;
-    header.sessionId = m_sessionId;
-
-    m_lastAckSent = cumulative;
-    std::vector<uint8_t> buffer = rnp::serialize(header, payload.data());
-
-    m_socket.async_send_to(asio::buffer(buffer), m_serverEndpoint,
-                           [this](const asio::error_code &error, std::size_t bytesTransferred)
-                           { handleSend(error, bytesTransferred); });
-}
-
-void eng::AsioClient::setPacketHandler(rnp::PacketType type, PacketHandler handler)
-{
-    m_packetHandlers[type] = handler;
-}
-
-void eng::AsioClient::setEventsHandler(std::function<void(const std::vector<rnp::EventRecord> &)> handler)
-{
-    m_eventsHandler = std::move(handler);
-}
-
-void eng::AsioClient::handleConnectAccept(const std::vector<uint8_t> &payload)
-{
-    if (payload.size() < 12)
-    {
-        std::cerr << "[AsioClient] Invalid CONNECT_ACCEPT payload\n";
-        return;
-    }
-
-    // session_id(4, BE)
-    m_sessionId = (static_cast<std::uint32_t>(payload[0]) << 24) | (static_cast<std::uint32_t>(payload[1]) << 16) |
-                  (static_cast<std::uint32_t>(payload[2]) << 8) | static_cast<std::uint32_t>(payload[3]);
-
-    // tick_rate_hz(2, BE)
-    m_serverTickRate = (static_cast<std::uint16_t>(payload[4]) << 8) | static_cast<std::uint16_t>(payload[5]);
-
-    // mtu_payload_bytes(2, BE)
-    m_serverMtu = (static_cast<std::uint16_t>(payload[6]) << 8) | static_cast<std::uint16_t>(payload[7]);
-
-    // server_caps(4, BE)
-    m_serverCaps = (static_cast<std::uint32_t>(payload[8]) << 24) | (static_cast<std::uint32_t>(payload[9]) << 16) |
-                   (static_cast<std::uint32_t>(payload[10]) << 8) | static_cast<std::uint32_t>(payload[11]);
-
-    m_connected = true;
-    std::cout << "[AsioClient] Connection accepted - Session ID: " << m_sessionId << ", Tick Rate: " << m_serverTickRate
-              << " Hz" << ", MTU: " << m_serverMtu << " bytes\n";
-}
-
-void eng::AsioClient::handleReliablePacket(const rnp::PacketHeader &header)
-{
-    // Track reliable packets (simplified implementation)
-    // In production, implement proper acknowledgment tracking
-}
-
-void eng::AsioClient::processAck(const std::vector<uint8_t> &payload)
-{
-    if (payload.size() < 8)
-    {
-        return;
-    }
-
-    // cumulative_ack (4 bytes, big endian)
-    std::uint32_t cumulative = (static_cast<std::uint32_t>(payload[0]) << 24) |
-                               (static_cast<std::uint32_t>(payload[1]) << 16) |
-                               (static_cast<std::uint32_t>(payload[2]) << 8) | static_cast<std::uint32_t>(payload[3]);
-
-    // ack_bits (4 bytes, big endian)
-    std::uint32_t ackBits = (static_cast<std::uint32_t>(payload[4]) << 24) |
-                            (static_cast<std::uint32_t>(payload[5]) << 16) |
-                            (static_cast<std::uint32_t>(payload[6]) << 8) | static_cast<std::uint32_t>(payload[7]);
-
-    // Remove acknowledged packets from pending reliable
-    m_pendingReliable.erase(cumulative);
-
-    // Process ack bits for selective acknowledgment
-    for (int i = 0; i < 32; ++i)
-    {
-        if (ackBits & (1 << i))
-        {
-            m_pendingReliable.erase(cumulative - i - 1);
-        }
-    }
-}
-
-void eng::AsioClient::processWorldState(const std::vector<uint8_t> &payload)
-{
-    if (payload.size() < 6)
-    {
-        return;
-    }
-
-    // server_tick (4 bytes, big endian)
-    std::uint32_t serverTick = (static_cast<std::uint32_t>(payload[0]) << 24) |
-                               (static_cast<std::uint32_t>(payload[1]) << 16) |
-                               (static_cast<std::uint32_t>(payload[2]) << 8) | static_cast<std::uint32_t>(payload[3]);
-
-    // entity_count (2 bytes, big endian)
-    std::uint16_t entityCount = (static_cast<std::uint16_t>(payload[4]) << 8) | static_cast<std::uint16_t>(payload[5]);
-
-    std::cout << "[AsioClient] World state received - Tick: " << serverTick << ", Entities: " << entityCount << "\n";
-
-    // TODO: Parse entities and call appropriate handler
-}
-
-void eng::AsioClient::processEntityEvent(const std::vector<uint8_t> &payload)
-{
-    try
-    {
-        if (payload.size() < 6)
-        {
-            // Legacy format without server_tick
-            const std::vector<rnp::EventRecord> events = rnp::deserializeEvents(payload.data(), payload.size());
-            if (m_eventsHandler)
-            {
-                m_eventsHandler(events);
-            }
+            utl::Logger::log("AsioClient: Already connected or connecting", utl::LogLevel::WARNING);
             return;
         }
 
-        // New format with server_tick
-        // server_tick (4 bytes, big endian)
-        std::uint32_t serverTick =
-            (static_cast<std::uint32_t>(payload[0]) << 24) | (static_cast<std::uint32_t>(payload[1]) << 16) |
-            (static_cast<std::uint32_t>(payload[2]) << 8) | static_cast<std::uint32_t>(payload[3]);
+        m_serverHost = host;
+        m_serverPort = port;
+        m_connectionState.store(ConnectionState::CONNECTING);
 
-        // event_count (2 bytes, big endian)
-        std::uint16_t eventCount =
-            (static_cast<std::uint16_t>(payload[4]) << 8) | static_cast<std::uint16_t>(payload[5]);
-
-        // Events serialized
-        const std::vector<rnp::EventRecord> events = rnp::deserializeEvents(payload.data() + 6, payload.size() - 6);
-
-        std::cout << "[AsioClient] Entity events received - Tick: " << serverTick << ", Events: " << eventCount << "\n";
-
-        if (m_eventsHandler)
+        try
         {
-            m_eventsHandler(events);
+            // Resolve server address
+            asio::ip::udp::resolver resolver(*m_ioContext);
+            auto endpoints = resolver.resolve(host, std::to_string(port));
+            m_serverEndpoint = *endpoints.begin();
+
+            // Open socket
+            m_socket->open(asio::ip::udp::v4());
+
+            m_running.store(true);
+
+            // Start network thread
+            m_networkThread = std::make_unique<std::thread>(&AsioClient::networkThreadLoop, this);
+
+            // Start receiving
+            startReceive();
+
+            // Send connect packet
+            sendConnect();
+
+            m_lastServerResponse = std::chrono::steady_clock::now();
+
+            utl::Logger::log("AsioClient: Connecting to " + host + ":" + std::to_string(port), utl::LogLevel::INFO);
+        }
+        catch (const std::exception &e)
+        {
+            m_connectionState.store(ConnectionState::DISCONNECTED);
+            m_running.store(false);
+            utl::Logger::log("AsioClient: Failed to connect - " + std::string(e.what()), utl::LogLevel::WARNING);
+            throw;
         }
     }
-    catch (const std::exception &e)
-    {
-        std::cerr << "[AsioClient] Erreur de parsing ENTITY_EVENT: " << e.what() << "\n";
-    }
-}
 
-void eng::AsioClient::retransmitReliable()
-{
-    // Simplified retransmission logic
-    // In production, track timestamps and implement exponential backoff
-    for (const auto &[seq, data] : m_pendingReliable)
+    void AsioClient::disconnect()
     {
-        m_socket.async_send_to(asio::buffer(data), m_serverEndpoint,
-                               [this](const asio::error_code &error, std::size_t bytesTransferred)
-                               { handleSend(error, bytesTransferred); });
-    }
-}
-
-void eng::AsioClient::startReceive()
-{
-    m_socket.async_receive_from(asio::buffer(m_recvBuffer), m_serverEndpoint,
-                                [this](const asio::error_code &error, std::size_t bytesTransferred)
-                                { handleReceive(error, bytesTransferred); });
-}
-
-void eng::AsioClient::handleReceive(const asio::error_code &error, std::size_t bytesTransferred)
-{
-    if (!error)
-    {
-        std::vector<uint8_t> data(m_recvBuffer.begin(), m_recvBuffer.begin() + bytesTransferred);
-        processPacket(data);
-        startReceive();
-    }
-    else if (error != asio::error::operation_aborted)
-    {
-        std::cerr << "[AsioClient] Erreur de réception: " << error.message() << "\n";
-        startReceive();
-    }
-}
-
-void eng::AsioClient::handleSend(const asio::error_code &error, std::size_t bytesTransferred)
-{
-    if (error)
-    {
-        std::cerr << "[AsioClient] Erreur d'envoi: " << error.message() << "\n";
-    }
-}
-
-void eng::AsioClient::processPacket(const std::vector<uint8_t> &data)
-{
-    try
-    {
-        rnp::PacketHeader header = rnp::deserializeHeader(data.data(), data.size());
-
-        std::vector<uint8_t> payload;
-        if (header.length > 0 && data.size() >= 16 + header.length)
+        if (m_connectionState.load() == ConnectionState::DISCONNECTED)
         {
-            payload.assign(data.begin() + 16, data.begin() + 16 + header.length);
-        }
-
-        // Vérifier la session ID (sauf pour CONNECT_ACCEPT)
-        if (static_cast<rnp::PacketType>(header.type) != rnp::PacketType::CONNECT_ACCEPT && m_sessionId != 0 &&
-            header.sessionId != m_sessionId)
-        {
-            std::cerr << "[AsioClient] Invalid session ID in packet\n";
             return;
         }
 
-        // Gérer les flags de fiabilité
-        if (header.flags & static_cast<std::uint16_t>(rnp::PacketFlags::RELIABLE))
+        m_connectionState.store(ConnectionState::DISCONNECTING);
+
+        // Send disconnect packet if connected
+        if (m_sessionId != 0)
         {
-            handleReliablePacket(header);
-        }
-        if (header.flags & static_cast<std::uint16_t>(rnp::PacketFlags::ACK_REQ))
-        {
-            sendAck(header.sequence, 0);
+            sendDisconnect();
+            std::this_thread::sleep_for(std::chrono::milliseconds(100)); // Allow time for packet to be sent
         }
 
-        switch (static_cast<rnp::PacketType>(header.type))
+        m_running.store(false);
+
+        // Stop io_context
+        if (m_ioContext)
         {
-            case rnp::PacketType::CONNECT_ACCEPT:
+            m_ioContext->stop();
+        }
+
+        // Wait for network thread
+        if (m_networkThread && m_networkThread->joinable())
+        {
+            m_networkThread->join();
+        }
+
+        // Close socket
+        if (m_socket && m_socket->is_open())
+        {
+            m_socket->close();
+        }
+
+        // Reset state
+        m_connectionState.store(ConnectionState::DISCONNECTED);
+        m_sessionId = 0;
+        m_serverTickRate = 60;
+        m_latency = 0;
+
+        // Clear send queue
+        {
+            std::lock_guard<std::mutex> lock(m_sendQueueMutex);
+            while (!m_sendQueue.empty())
             {
-                handleConnectAccept(payload);
-                break;
+                m_sendQueue.pop();
             }
-            case rnp::PacketType::WORLD_STATE:
+        }
+
+        utl::Logger::log("AsioClient: Disconnected", utl::LogLevel::INFO);
+    }
+
+    void AsioClient::update()
+    {
+        if (!m_running.load())
+        {
+            return;
+        }
+
+        std::cout << "[CLIENT DEBUG] AsioClient::update() called\n";
+
+        // Process send queue
+        processSendQueue();
+
+        // Update connection management
+        updateConnectionManagement();
+    }
+
+    bool AsioClient::isConnected() const { return m_connectionState.load() == ConnectionState::CONNECTED; }
+
+    ConnectionState AsioClient::getConnectionState() const { return m_connectionState.load(); }
+
+    std::uint32_t AsioClient::getSessionId() const { return m_sessionId; }
+
+    std::uint16_t AsioClient::getServerTickRate() const { return m_serverTickRate; }
+
+    std::uint32_t AsioClient::getLatency() const { return m_latency; }
+
+    void AsioClient::setPlayerName(const std::string &playerName)
+    {
+        m_playerName = playerName;
+        utl::Logger::log("AsioClient: Player name set to " + playerName, utl::LogLevel::INFO);
+    }
+
+    void AsioClient::setClientCapabilities(std::uint32_t caps)
+    {
+        m_clientCaps = caps;
+        utl::Logger::log("AsioClient: Client capabilities set to " + std::to_string(caps), utl::LogLevel::INFO);
+    }
+
+    void AsioClient::sendToServer(const std::vector<std::uint8_t> &data, bool reliable)
+    {
+        if (m_connectionState.load() != ConnectionState::CONNECTED)
+        {
+            utl::Logger::log("AsioClient: Attempted to send while not connected", utl::LogLevel::WARNING);
+            return;
+        }
+
+        std::lock_guard<std::mutex> lock(m_sendQueueMutex);
+        m_sendQueue.emplace(data, reliable);
+    }
+
+    void AsioClient::setupPacketHandlers()
+    {
+        // CONNECT_ACCEPT handler
+        m_packetHandler->onConnectAccept(
+            [this](const rnp::PacketConnectAccept &packet, const rnp::PacketContext &context)
+            { return handleConnectAccept(packet, context); });
+
+        // DISCONNECT handler
+        m_packetHandler->onDisconnect([this](const rnp::PacketDisconnect &packet, const rnp::PacketContext &context)
+                                      { return handleDisconnect(packet, context); });
+
+        // PONG handler
+        m_packetHandler->onPong([this](const rnp::PacketPingPong &packet, const rnp::PacketContext &context)
+                                { return handlePong(packet, context); });
+
+        // PING handler (server can ping client too)
+        m_packetHandler->onPing([this](const rnp::PacketPingPong &packet, const rnp::PacketContext &context)
+                                { return handlePing(packet, context); });
+
+        // ERROR handler
+        m_packetHandler->onError([this](const rnp::PacketError &packet, const rnp::PacketContext &context)
+                                 { return handleError(packet, context); });
+
+        // WORLD_STATE handler
+        m_packetHandler->onWorldState([this](const rnp::PacketWorldState &packet, const rnp::PacketContext &context)
+                                      { return handleWorldState(packet, context); });
+
+        utl::Logger::log("AsioClient: Packet handlers initialized", utl::LogLevel::INFO);
+    }
+
+    void AsioClient::startReceive()
+    {
+        m_socket->async_receive_from(asio::buffer(m_recvBuffer), m_senderEndpoint,
+                                     [this](std::error_code ec, std::size_t bytesReceived)
+                                     {
+                                         if (!ec && m_running.load())
+                                         {
+                                             handleReceive(bytesReceived);
+                                             startReceive(); // Continue receiving
+                                         }
+                                         else if (m_running.load())
+                                         {
+                                             utl::Logger::log("AsioClient: Receive error - " + ec.message(),
+                                                              utl::LogLevel::WARNING);
+                                             startReceive(); // Try to continue
+                                         }
+                                     });
+    }
+
+    void AsioClient::handleReceive(std::size_t bytesReceived)
+    {
+        if (bytesReceived < sizeof(rnp::PacketHeader))
+        {
+            utl::Logger::log("AsioClient: Received packet too small", utl::LogLevel::WARNING);
+            return;
+        }
+
+        m_lastServerResponse = std::chrono::steady_clock::now();
+        m_stats.packetsReceived++;
+        m_stats.bytesTransferred += bytesReceived;
+
+        // Create packet context
+        rnp::PacketContext context;
+        context.receiveTime = std::chrono::steady_clock::now();
+        context.senderAddress = m_senderEndpoint.address().to_string();
+        context.senderPort = m_senderEndpoint.port();
+
+        // Extract session ID from header for context
+        std::vector<std::uint8_t> data(m_recvBuffer.begin(), m_recvBuffer.begin() + bytesReceived);
+        if (data.size() >= sizeof(rnp::PacketHeader))
+        {
+            rnp::Serializer headerSerializer(data);
+            rnp::PacketHeader header = headerSerializer.deserializeHeader();
+            context.sessionId = header.sessionId;
+        }
+
+        // Process packet
+        rnp::HandlerResult result = m_packetHandler->processPacket(data, context);
+        if (result != rnp::HandlerResult::SUCCESS)
+        {
+            utl::Logger::log("AsioClient: Packet processing failed with result " +
+                                 std::to_string(static_cast<int>(result)),
+                             utl::LogLevel::WARNING);
+        }
+    }
+
+    void AsioClient::networkThreadLoop()
+    {
+        utl::Logger::log("AsioClient: Network thread started", utl::LogLevel::INFO);
+
+        while (m_running.load())
+        {
+            try
             {
-                processWorldState(payload);
-                break;
-            }
-            case rnp::PacketType::ENTITY_EVENT:
-            {
-                processEntityEvent(payload);
-                break;
-            }
-            case rnp::PacketType::ACK:
-            {
-                processAck(payload);
-                break;
-            }
-            case rnp::PacketType::PACKET_ERROR:
-            {
-                if (payload.size() >= 4)
+                m_ioContext->run_for(std::chrono::milliseconds(100));
+                if (!m_running.load())
                 {
-                    std::uint16_t errorCode =
-                        (static_cast<std::uint16_t>(payload[0]) << 8) | static_cast<std::uint16_t>(payload[1]);
-                    std::uint16_t msgLen =
-                        (static_cast<std::uint16_t>(payload[2]) << 8) | static_cast<std::uint16_t>(payload[3]);
-                    if (payload.size() >= 4 + msgLen)
-                    {
-                        std::string errorMsg(payload.begin() + 4, payload.begin() + 4 + msgLen);
-                        std::cerr << "[AsioClient] Error " << errorCode << ": " << errorMsg << "\n";
-                    }
+                    break;
                 }
-                break;
+                m_ioContext->restart();
             }
-            case rnp::PacketType::PONG:
+            catch (const std::exception &e)
             {
-                if (payload.size() >= 8)
-                {
-                    std::uint32_t nonce = (static_cast<std::uint32_t>(payload[0]) << 24) |
-                                          (static_cast<std::uint32_t>(payload[1]) << 16) |
-                                          (static_cast<std::uint32_t>(payload[2]) << 8) |
-                                          static_cast<std::uint32_t>(payload[3]);
-                    std::uint32_t sendTime = (static_cast<std::uint32_t>(payload[4]) << 24) |
-                                             (static_cast<std::uint32_t>(payload[5]) << 16) |
-                                             (static_cast<std::uint32_t>(payload[6]) << 8) |
-                                             static_cast<std::uint32_t>(payload[7]);
-                    std::cout << "[AsioClient] PONG received - nonce: " << nonce << ", time: " << sendTime << "\n";
-                }
-                break;
+                utl::Logger::log("AsioClient: Network thread exception - " + std::string(e.what()),
+                                 utl::LogLevel::WARNING);
+                std::this_thread::sleep_for(std::chrono::milliseconds(100));
             }
+        }
+
+        utl::Logger::log("AsioClient: Network thread stopped", utl::LogLevel::INFO);
+    }
+
+    void AsioClient::sendPacketImmediate(const std::vector<std::uint8_t> &data)
+    {
+        if (!m_socket || !m_socket->is_open())
+        {
+            return;
+        }
+
+        try
+        {
+            m_socket->send_to(asio::buffer(data), m_serverEndpoint);
+            m_stats.packetsSent++;
+            m_stats.bytesTransferred += data.size();
+        }
+        catch (const std::exception &e)
+        {
+            utl::Logger::log("AsioClient: Failed to send packet - " + std::string(e.what()), utl::LogLevel::WARNING);
+        }
+    }
+
+    rnp::HandlerResult AsioClient::handleConnectAccept(const rnp::PacketConnectAccept &packet,
+                                                       const rnp::PacketContext &context)
+    {
+        m_sessionId = packet.sessionId;
+        m_serverTickRate = packet.tickRateHz;
+        m_connectionState.store(ConnectionState::CONNECTED);
+
+        utl::Logger::log("AsioClient: Connection accepted - Session ID: " + std::to_string(m_sessionId) +
+                             ", Tick rate: " + std::to_string(m_serverTickRate) + "Hz",
+                         utl::LogLevel::INFO);
+
+        return rnp::HandlerResult::SUCCESS;
+    }
+
+    rnp::HandlerResult AsioClient::handleDisconnect(const rnp::PacketDisconnect &packet,
+                                                    const rnp::PacketContext &context)
+    {
+        auto reason = static_cast<rnp::DisconnectReason>(packet.reasonCode);
+        std::string reasonStr = "Unknown";
+
+        switch (reason)
+        {
+            case rnp::DisconnectReason::CLIENT_REQUEST:
+                reasonStr = "Client request";
+                break;
+            case rnp::DisconnectReason::TIMEOUT:
+                reasonStr = "Timeout";
+                break;
+            case rnp::DisconnectReason::PROTOCOL_ERROR:
+                reasonStr = "Protocol error";
+                break;
+            case rnp::DisconnectReason::SERVER_SHUTDOWN:
+                reasonStr = "Server shutdown";
+                break;
+            case rnp::DisconnectReason::SERVER_FULL:
+                reasonStr = "Server full";
+                break;
+            case rnp::DisconnectReason::BANNED:
+                reasonStr = "Banned";
+                break;
+            case rnp::DisconnectReason::UNSPECIFIED:
+                reasonStr = "Unspecified";
+                break;
+        }
+
+        utl::Logger::log("AsioClient: Disconnected by server - Reason: " + reasonStr, utl::LogLevel::INFO);
+
+        m_connectionState.store(ConnectionState::DISCONNECTED);
+        m_sessionId = 0;
+
+        return rnp::HandlerResult::SUCCESS;
+    }
+
+    rnp::HandlerResult AsioClient::handlePong(const rnp::PacketPingPong &packet, const rnp::PacketContext &context)
+    {
+        if (packet.nonce == m_lastPingNonce)
+        {
+            auto now = std::chrono::steady_clock::now();
+            auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(now - m_lastPingTime);
+            m_latency = static_cast<std::uint32_t>(duration.count());
+
+            utl::Logger::log("AsioClient: Ping response received - Latency: " + std::to_string(m_latency) + "ms",
+                             utl::LogLevel::INFO);
+        }
+
+        return rnp::HandlerResult::SUCCESS;
+    }
+
+    rnp::HandlerResult AsioClient::handlePing(const rnp::PacketPingPong &packet, const rnp::PacketContext &context)
+    {
+        // Server is pinging us, send pong response
+        sendPong(packet.nonce);
+        return rnp::HandlerResult::SUCCESS;
+    }
+
+    rnp::HandlerResult AsioClient::handleError(const rnp::PacketError &packet, const rnp::PacketContext &context)
+    {
+        auto errorCode = static_cast<rnp::ErrorCode>(packet.errorCode);
+        std::string errorStr = "Unknown error";
+
+        switch (errorCode)
+        {
+            case rnp::ErrorCode::INVALID_PAYLOAD:
+                errorStr = "Invalid payload";
+                break;
+            case rnp::ErrorCode::UNAUTHORIZED_SESSION:
+                errorStr = "Unauthorized session";
+                break;
+            case rnp::ErrorCode::RATE_LIMITED:
+                errorStr = "Rate limited";
+                break;
+            case rnp::ErrorCode::INTERNAL_ERROR:
+                errorStr = "Internal server error";
+                break;
             default:
+                errorStr = "Unknown error";
                 break;
         }
 
-        // Appeler les handlers personnalisés
-        auto it = m_packetHandlers.find(static_cast<rnp::PacketType>(header.type));
-        if (it != m_packetHandlers.end())
+        utl::Logger::log("AsioClient: Server error - " + errorStr + ": " + packet.description, utl::LogLevel::WARNING);
+
+        return rnp::HandlerResult::SUCCESS;
+    }
+
+    rnp::HandlerResult AsioClient::handleWorldState(const rnp::PacketWorldState &packet,
+                                                    const rnp::PacketContext &context)
+    {
+        // Handle world state update
+        utl::Logger::log("AsioClient: World state received - Tick: " + std::to_string(packet.serverTick) +
+                             ", Entities: " + std::to_string(packet.entityCount),
+                         utl::LogLevel::INFO);
+
+        // TODO: Forward to game engine for processing
+        return rnp::HandlerResult::SUCCESS;
+    }
+
+    void AsioClient::sendConnect()
+    {
+        rnp::Serializer serializer;
+        rnp::PacketHeader header{};
+        header.type = static_cast<std::uint8_t>(rnp::PacketType::CONNECT);
+        header.length = sizeof(rnp::PacketConnect);
+        header.flags = 0;
+        header.sessionId = 0; // No session ID yet
+
+        rnp::PacketConnect connect{};
+        connect.nameLen = static_cast<std::uint8_t>(
+            std::min(m_playerName.length(), static_cast<std::size_t>(connect.playerName.size() - 1)));
+        std::memset(connect.playerName.data(), 0, connect.playerName.size());
+        if (!m_playerName.empty())
         {
-            it->second(header, payload);
+            std::memcpy(connect.playerName.data(), m_playerName.data(), connect.nameLen);
+        }
+        connect.clientCaps = m_clientCaps;
+
+        serializer.serializeHeader(header);
+        serializer.serializeConnect(connect);
+
+        sendPacketImmediate(serializer.getData());
+        utl::Logger::log("AsioClient: CONNECT packet sent", utl::LogLevel::INFO);
+    }
+
+    void AsioClient::sendDisconnect()
+    {
+        if (m_sessionId == 0)
+        {
+            return;
+        }
+
+        rnp::Serializer serializer;
+        rnp::PacketHeader header{};
+        header.type = static_cast<std::uint8_t>(rnp::PacketType::DISCONNECT);
+        header.length = sizeof(rnp::PacketDisconnect);
+        header.flags = 0;
+        header.sessionId = m_sessionId;
+
+        rnp::PacketDisconnect disconnect{};
+        disconnect.reasonCode = static_cast<std::uint16_t>(rnp::DisconnectReason::CLIENT_REQUEST);
+
+        serializer.serializeHeader(header);
+        serializer.serializeDisconnect(disconnect);
+
+        sendPacketImmediate(serializer.getData());
+        utl::Logger::log("AsioClient: DISCONNECT packet sent", utl::LogLevel::INFO);
+    }
+
+    void AsioClient::sendPing()
+    {
+        if (m_sessionId == 0)
+        {
+            return;
+        }
+
+        m_lastPingNonce = generatePingNonce();
+        m_lastPingTime = std::chrono::steady_clock::now();
+
+        rnp::Serializer serializer;
+        rnp::PacketHeader header{};
+        header.type = static_cast<std::uint8_t>(rnp::PacketType::PING);
+        header.length = sizeof(rnp::PacketPingPong);
+        header.flags = 0;
+        header.sessionId = m_sessionId;
+
+        rnp::PacketPingPong ping{};
+        ping.nonce = m_lastPingNonce;
+        ping.sendTimeMs = static_cast<std::uint32_t>(
+            std::chrono::duration_cast<std::chrono::milliseconds>(m_lastPingTime.time_since_epoch()).count());
+
+        serializer.serializeHeader(header);
+        serializer.serializePingPong(ping);
+
+        sendPacketImmediate(serializer.getData());
+    }
+
+    void AsioClient::sendPong(std::uint32_t nonce)
+    {
+        if (m_sessionId == 0)
+        {
+            return;
+        }
+
+        rnp::Serializer serializer;
+        rnp::PacketHeader header{};
+        header.type = static_cast<std::uint8_t>(rnp::PacketType::PONG);
+        header.length = sizeof(rnp::PacketPingPong);
+        header.flags = 0;
+        header.sessionId = m_sessionId;
+
+        rnp::PacketPingPong pong{};
+        pong.nonce = nonce;
+        pong.sendTimeMs = static_cast<std::uint32_t>(
+            std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now().time_since_epoch())
+                .count());
+
+        serializer.serializeHeader(header);
+        serializer.serializePingPong(pong);
+
+        sendPacketImmediate(serializer.getData());
+    }
+
+    void AsioClient::processSendQueue()
+    {
+        std::lock_guard<std::mutex> lock(m_sendQueueMutex);
+        while (!m_sendQueue.empty())
+        {
+            const QueuedPacket &packet = m_sendQueue.front();
+            sendPacketImmediate(packet.data);
+            m_sendQueue.pop();
         }
     }
-    catch (const std::exception &e)
+
+    void AsioClient::updateConnectionManagement()
     {
-        std::cerr << "[AsioClient] Erreur de traitement du paquet: " << e.what() << "\n";
+        auto now = std::chrono::steady_clock::now();
+
+        // Send periodic pings when connected
+        if (m_connectionState.load() == ConnectionState::CONNECTED)
+        {
+            if (now - m_lastPingTime > m_pingInterval)
+            {
+                sendPing();
+            }
+        }
+
+        // Check for connection timeout
+        if (m_connectionState.load() == ConnectionState::CONNECTING ||
+            m_connectionState.load() == ConnectionState::CONNECTED)
+        {
+            if (now - m_lastServerResponse > m_connectionTimeout)
+            {
+                utl::Logger::log("AsioClient: Connection timed out", utl::LogLevel::WARNING);
+                m_connectionState.store(ConnectionState::DISCONNECTED);
+                m_sessionId = 0;
+            }
+        }
+
+        // Retry connection if in CONNECTING state and enough time has passed
+        if (m_connectionState.load() == ConnectionState::CONNECTING)
+        {
+            static auto lastConnectAttempt = std::chrono::steady_clock::now();
+            if (now - lastConnectAttempt > std::chrono::seconds(2))
+            {
+                sendConnect();
+                lastConnectAttempt = now;
+            }
+        }
     }
-}
+
+    std::uint32_t AsioClient::generatePingNonce()
+    {
+        static std::random_device rd;
+        static std::mt19937 gen(rd());
+        static std::uniform_int_distribution<std::uint32_t> dis(1, UINT32_MAX);
+        return dis(gen);
+    }
+
+} // namespace eng

--- a/plugins/Network/Asio/Client/src/entrypoint.cpp
+++ b/plugins/Network/Asio/Client/src/entrypoint.cpp
@@ -1,6 +1,7 @@
 #include <memory>
 
 #include "AsioClient/AsioClient.hpp"
+#include "Utils/Interfaces/IPlugin.hpp"
 
 extern "C"
 {

--- a/plugins/Network/Asio/Server/CMakeLists.txt
+++ b/plugins/Network/Asio/Server/CMakeLists.txt
@@ -15,6 +15,7 @@ target_include_directories(${PROJECT_NAME} PRIVATE
         "${CMAKE_SOURCE_DIR}/modules/Interfaces/include"
         "${CMAKE_SOURCE_DIR}/modules/Utils/include"
         "${CMAKE_SOURCE_DIR}/third-party/asio/asio/include"
+        "${CMAKE_SOURCE_DIR}/plugins/Network/Protocol/include"
 )
 target_compile_options(${PROJECT_NAME} PRIVATE ${WARNING_FLAGS})
 target_link_libraries(${PROJECT_NAME} PRIVATE utils)

--- a/plugins/Network/Asio/Server/include/AsioServer/AsioServer.hpp
+++ b/plugins/Network/Asio/Server/include/AsioServer/AsioServer.hpp
@@ -1,115 +1,246 @@
 ///
 /// @file AsioServer.hpp
-/// @brief This file contains the server network implementation for Asio
+/// @brief Asio-based implementation of INetworkServer interface
 /// @namespace srv
 ///
 
 #pragma once
 
-#include <functional>
-#include <string>
+#include "Interfaces/INetworkServer.hpp"
+#include "Interfaces/Protocol/HandlerPacket.hpp"
+#include "Interfaces/Protocol/Protocol.hpp"
+#include "Interfaces/Protocol/Serializer.hpp"
+
+#include <asio.hpp>
+#include <atomic>
+#include <memory>
+#include <mutex>
+#include <queue>
 #include <thread>
 #include <unordered_map>
 #include <vector>
-
-#define ASIO_STANDALONE
-#include "asio.hpp"
-
-#include "Interfaces/INetworkServer.hpp"
-#include "Interfaces/Protocol/Protocol.hpp"
 
 namespace srv
 {
 
     ///
+    /// @brief Client session information
+    ///
+    struct ClientSession
+    {
+            std::uint32_t sessionId;
+            asio::ip::udp::endpoint endpoint;
+            std::chrono::steady_clock::time_point lastSeen;
+            std::string playerName;
+            std::uint32_t clientCaps;
+            bool isConnected;
+            std::uint32_t lastPingSent;
+            std::uint32_t latency;
+
+            ClientSession()
+                : sessionId(0), lastSeen(std::chrono::steady_clock::now()), clientCaps(0), isConnected(false),
+                  lastPingSent(0), latency(0)
+            {
+            }
+    };
+
+    ///
+    /// @brief Queued packet for sending
+    ///
+    struct QueuedPacket
+    {
+            std::vector<std::uint8_t> data;
+            asio::ip::udp::endpoint destination;
+            bool reliable;
+
+            QueuedPacket(const std::vector<std::uint8_t> &d, const asio::ip::udp::endpoint &dest, bool rel = false)
+                : data(d), destination(dest), reliable(rel)
+            {
+            }
+    };
+
+    ///
     /// @class AsioServer
-    /// @brief Network implementation with asio for server
+    /// @brief Asio UDP server implementation
     /// @namespace srv
     ///
-    class AsioServer final : public INetworkServer
+    class AsioServer : public INetworkServer
     {
-        public:
-            using PacketHandler = std::function<void(const asio::ip::udp::endpoint &, const rnp::PacketHeader &,
-                                                     const std::vector<uint8_t> &)>;
-            using ClientInfo = struct
-            {
-                    asio::ip::udp::endpoint endpoint;
-                    std::string playerName;
-                    uint32_t lastSequence;
-                    bool connected;
-                    std::uint16_t playerId;
-                    std::uint32_t sessionId;
-                    std::uint32_t clientCaps;
-            };
+        private:
+            // Network components
+            std::unique_ptr<asio::io_context> m_ioContext;
+            std::unique_ptr<asio::ip::udp::socket> m_socket;
+            std::unique_ptr<std::thread> m_networkThread;
 
+            // Server configuration
+            std::string m_host;
+            std::uint16_t m_port;
+            std::uint16_t m_tickRate;
+            std::uint32_t m_serverCaps;
+
+            // Server state
+            std::atomic<bool> m_running;
+            std::atomic<bool> m_started;
+
+            // Client management
+            std::unordered_map<std::uint32_t, ClientSession> m_clients;
+            std::unordered_map<std::string, std::uint32_t> m_endpointToSession;
+            std::uint32_t m_nextSessionId;
+            mutable std::mutex m_clientsMutex;
+
+            // Packet handling
+            std::unique_ptr<rnp::HandlerPacket> m_packetHandler;
+            std::queue<QueuedPacket> m_sendQueue;
+            std::mutex m_sendQueueMutex;
+            std::mutex m_socketMutex;
+
+            // Reception buffer
+            std::array<std::uint8_t, MAX_LEN_RECV_BUFFER> m_recvBuffer;
+            asio::ip::udp::endpoint m_senderEndpoint;
+
+            // Timing
+            std::chrono::steady_clock::time_point m_lastPingTime;
+            std::chrono::milliseconds m_pingInterval;
+            std::chrono::milliseconds m_clientTimeout;
+
+            ///
+            /// @brief Initialize packet handlers
+            ///
+            void setupPacketHandlers();
+
+            ///
+            /// @brief Start receiving packets asynchronously
+            ///
+            void startReceive();
+
+            ///
+            /// @brief Handle received packet
+            /// @param bytesReceived Number of bytes received
+            ///
+            void handleReceive(std::size_t bytesReceived);
+
+            ///
+            /// @brief Network thread main loop
+            ///
+            void networkThreadLoop();
+
+            ///
+            /// @brief Generate unique session ID
+            /// @return New session ID
+            ///
+            std::uint32_t generateSessionId();
+
+            ///
+            /// @brief Get endpoint string representation
+            /// @param endpoint UDP endpoint
+            /// @return String representation
+            ///
+            std::string endpointToString(const asio::ip::udp::endpoint &endpoint) const;
+
+            ///
+            /// @brief Send packet immediately
+            /// @param data Packet data
+            /// @param destination Target endpoint
+            ///
+            void sendPacketImmediate(const std::vector<std::uint8_t> &data, const asio::ip::udp::endpoint &destination);
+
+            ///
+            /// @brief Handle CONNECT packet
+            /// @param packet Connect packet
+            /// @param context Packet context
+            /// @return Handler result
+            ///
+            rnp::HandlerResult handleConnect(const rnp::PacketConnect &packet, const rnp::PacketContext &context);
+
+            ///
+            /// @brief Handle DISCONNECT packet
+            /// @param packet Disconnect packet
+            /// @param context Packet context
+            /// @return Handler result
+            ///
+            rnp::HandlerResult handleDisconnect(const rnp::PacketDisconnect &packet, const rnp::PacketContext &context);
+
+            ///
+            /// @brief Handle PING packet
+            /// @param packet Ping packet
+            /// @param context Packet context
+            /// @return Handler result
+            ///
+            rnp::HandlerResult handlePing(const rnp::PacketPingPong &packet, const rnp::PacketContext &context);
+
+            ///
+            /// @brief Handle PONG packet
+            /// @param packet Pong packet
+            /// @param context Packet context
+            /// @return Handler result
+            ///
+            rnp::HandlerResult handlePong(const rnp::PacketPingPong &packet, const rnp::PacketContext &context);
+
+            ///
+            /// @brief Send PONG response
+            /// @param nonce Ping nonce
+            /// @param destination Target endpoint
+            /// @param sessionId Client session ID
+            ///
+            void sendPong(std::uint32_t nonce, const asio::ip::udp::endpoint &destination, std::uint32_t sessionId);
+
+            ///
+            /// @brief Send CONNECT_ACCEPT response
+            /// @param sessionId New session ID
+            /// @param destination Target endpoint
+            ///
+            void sendConnectAccept(std::uint32_t sessionId, const asio::ip::udp::endpoint &destination);
+
+            ///
+            /// @brief Send ERROR packet
+            /// @param errorCode Error code
+            /// @param description Error description
+            /// @param destination Target endpoint
+            /// @param sessionId Session ID
+            ///
+            void sendError(rnp::ErrorCode errorCode, const std::string &description,
+                           const asio::ip::udp::endpoint &destination, std::uint32_t sessionId);
+
+            ///
+            /// @brief Update client timeouts and send pings
+            ///
+            void updateClientManagement();
+
+            ///
+            /// @brief Process send queue
+            ///
+            void processSendQueue();
+
+        public:
+            ///
+            /// @brief Constructor
+            ///
             AsioServer();
+
+            ///
+            /// @brief Destructor
+            ///
             ~AsioServer() override;
 
-            AsioServer(const AsioServer &) = delete;
-            AsioServer(AsioServer &&) = delete;
-            AsioServer &operator=(const AsioServer &) = delete;
-            AsioServer &operator=(AsioServer &&) = delete;
-
-            void init(const std::string &host, uint16_t port) override;
             [[nodiscard]] const std::string getName() const override { return "Network_Asio_Server"; }
-            [[nodiscard]] utl::PluginType getType() const override { return utl::PluginType::NETWORK_SERVER; }
+            [[nodiscard]] utl::PluginType getType() const override { return utl::PluginType::NETWORK_CLIENT; }
 
+            // INetworkServer implementation
+            void init(const std::string &host, std::uint16_t port) override;
             void start() override;
             void stop() override;
+            void update() override;
+            void sendToClient(std::uint32_t sessionId, const std::vector<std::uint8_t> &data,
+                              bool reliable = false) override;
+            void sendToAllClients(const std::vector<std::uint8_t> &data, bool reliable = false) override;
+            void disconnectClient(std::uint32_t sessionId) override;
 
-            void sendConnectAccept(const asio::ip::udp::endpoint &client, std::uint32_t sessionId);
-            void sendWorldState(const asio::ip::udp::endpoint &client, std::uint32_t serverTick,
-                                const std::vector<rnp::EntityState> &entities);
-            void sendWorldState(const asio::ip::udp::endpoint &client, const std::vector<uint8_t> &worldData);
-            void sendEntityEvent(const asio::ip::udp::endpoint &client, std::uint32_t serverTick,
-                                 const std::vector<rnp::EventRecord> &events);
-            void sendEvents(const asio::ip::udp::endpoint &client, const std::vector<rnp::EventRecord> &events);
-            void sendPong(const asio::ip::udp::endpoint &client, std::uint32_t nonce, std::uint32_t sendTimeMs);
-            void sendPong(const asio::ip::udp::endpoint &client);
-            void sendError(const asio::ip::udp::endpoint &client, rnp::ErrorCode errorCode,
-                           const std::string &errorMessage);
-            void sendError(const asio::ip::udp::endpoint &client, const std::string &errorMessage);
-            void sendAck(const asio::ip::udp::endpoint &client, std::uint32_t cumulative, std::uint32_t ackBits);
-            void broadcastToAll(const std::vector<uint8_t> &data);
-            void broadcastEntityEvents(std::uint32_t serverTick, const std::vector<rnp::EventRecord> &events);
-            void broadcastEvents(const std::vector<rnp::EventRecord> &events);
+            [[nodiscard]] std::size_t getClientCount() const override;
+            [[nodiscard]] std::vector<std::uint32_t> getConnectedSessions() const override;
+            [[nodiscard]] bool isRunning() const override;
 
-            void setPacketHandler(rnp::PacketType type, PacketHandler handler);
-            void setTickRate(std::uint16_t tickRate) { m_tickRateHz = tickRate; }
-            void setServerCapabilities(std::uint32_t caps) { m_serverCaps = caps; }
+            void setTickRate(std::uint16_t tickRate) override;
+            void setServerCapabilities(std::uint32_t caps) override;
+    };
 
-            const std::unordered_map<asio::ip::udp::endpoint, ClientInfo> &getClients() const { return m_clients; }
-
-        private:
-            void startReceive();
-            void handleReceive(const asio::error_code &error, std::size_t bytesTransferred);
-            void handleSend(const asio::error_code &error, std::size_t bytesTransferred);
-            void processPacket(const asio::ip::udp::endpoint &sender, const std::vector<uint8_t> &data);
-            void addClient(const asio::ip::udp::endpoint &endpoint, const std::string &playerName,
-                           std::uint32_t clientCaps, std::uint32_t sessionId);
-            void removeClient(const asio::ip::udp::endpoint &endpoint);
-            std::uint16_t getPlayerId(const asio::ip::udp::endpoint &endpoint) const;
-            std::uint32_t getSessionId(const asio::ip::udp::endpoint &endpoint) const;
-            void handleReliablePacket(const asio::ip::udp::endpoint &sender, const rnp::PacketHeader &header);
-            void processAck(const asio::ip::udp::endpoint &sender, const std::vector<uint8_t> &payload);
-            void retransmitReliable();
-
-            asio::io_context m_ioContext;
-            asio::ip::udp::socket m_socket;
-            asio::ip::udp::endpoint m_remoteEndpoint;
-            std::array<uint8_t, rnp::MAX_PAYLOAD + 16> m_recvBuffer;
-
-            std::unique_ptr<asio::executor_work_guard<asio::io_context::executor_type>> m_workGuard;
-            std::thread m_ioThread;
-            std::unordered_map<asio::ip::udp::endpoint, ClientInfo> m_clients;
-            std::unordered_map<rnp::PacketType, PacketHandler> m_packetHandlers;
-            uint32_t m_sequenceNumber = 0;
-            std::uint16_t m_nextPlayerId = 1;
-            std::uint32_t m_nextSessionId = 1;
-            std::uint16_t m_tickRateHz = 60;
-            std::uint16_t m_mtuPayloadBytes = 508;
-            std::uint32_t m_serverCaps = 0;
-            std::unordered_map<std::uint32_t, std::vector<uint8_t>> m_pendingReliable;
-            std::unordered_map<asio::ip::udp::endpoint, std::uint32_t> m_clientLastAck;
-    }; // class AsioServer
 } // namespace srv

--- a/plugins/Network/Asio/Server/src/asioServer.cpp
+++ b/plugins/Network/Asio/Server/src/asioServer.cpp
@@ -1,737 +1,811 @@
-#include <cstring>
-#include <iostream>
+///
+/// @file AsioServer.cpp
+/// @brief Asio-based implementation of INetworkServer interface
+/// @namespace srv
+///
 
 #include "AsioServer/AsioServer.hpp"
+#include "Utils/Logger.hpp"
 
-using asio::ip::udp;
+#include <chrono>
+#include <iostream>
+#include <random>
 
-srv::AsioServer::AsioServer() : m_socket(m_ioContext), m_recvBuffer() {}
-
-void srv::AsioServer::init(const std::string &host, const uint16_t port)
+namespace srv
 {
-    const asio::ip::address addr = asio::ip::make_address(host);
-    const udp::endpoint ep(addr, port);
 
-    m_socket.open(ep.protocol());
-    m_socket.set_option(asio::socket_base::reuse_address(true));
-    m_socket.bind(ep);
-}
+    AsioServer::AsioServer()
+        : m_ioContext(std::make_unique<asio::io_context>()),
+          m_socket(std::make_unique<asio::ip::udp::socket>(*m_ioContext)), m_port(0), m_tickRate(60), m_serverCaps(0),
+          m_running(false), m_started(false), m_nextSessionId(1),
+          m_packetHandler(std::make_unique<rnp::HandlerPacket>()), m_pingInterval(std::chrono::seconds(5)),
+          m_clientTimeout(std::chrono::seconds(30))
+    {
+        utl::Logger::log("AsioServer: Constructor called", utl::LogLevel::INFO);
+        utl::Logger::log("AsioServer: Creating I/O context and socket", utl::LogLevel::INFO);
+        setupPacketHandlers();
+        utl::Logger::log("AsioServer: Packet handlers setup complete", utl::LogLevel::INFO);
+        utl::Logger::log("AsioServer: Initialized successfully", utl::LogLevel::INFO);
+    }
 
-void srv::AsioServer::start()
-{
-    m_workGuard = std::make_unique<asio::executor_work_guard<asio::io_context::executor_type>>(
-        asio::make_work_guard(m_ioContext));
+    AsioServer::~AsioServer()
+    {
+        utl::Logger::log("AsioServer: Destructor called", utl::LogLevel::INFO);
+        stop();
+        utl::Logger::log("AsioServer: Destroyed", utl::LogLevel::INFO);
+    }
 
-    startReceive();
+    void AsioServer::init(const std::string &host, std::uint16_t port)
+    {
+        utl::Logger::log("AsioServer: init() called with host=" + host + ", port=" + std::to_string(port),
+                         utl::LogLevel::INFO);
+        m_host = host;
+        m_port = port;
+        utl::Logger::log("AsioServer: Configuration stored - ready to start", utl::LogLevel::INFO);
+    }
 
-    m_ioThread = std::thread(
-        [this]
+    void AsioServer::start()
+    {
+        utl::Logger::log("AsioServer: Starting server...", utl::LogLevel::INFO);
+
+        if (m_started.load())
         {
-            try
-            {
-                m_ioContext.run();
-            }
-            catch (const std::exception &e)
-            {
-                std::cerr << "[AsioServer] IO context exception: " << e.what() << "\n";
-            }
-        });
-}
-
-void srv::AsioServer::stop()
-{
-    if (m_workGuard)
-    {
-        asio::post(m_ioContext,
-                   [this]
-                   {
-                       asio::error_code ec;
-                       m_socket.close(ec);
-                   });
-
-        m_workGuard.reset();
-    }
-
-    m_ioContext.stop();
-
-    if (m_ioThread.joinable())
-    {
-        m_ioThread.join();
-    }
-}
-
-srv::AsioServer::~AsioServer() { stop(); }
-
-void srv::AsioServer::startReceive()
-{
-    m_socket.async_receive_from(asio::buffer(m_recvBuffer), m_remoteEndpoint,
-                                [this](const asio::error_code &ec, const std::size_t n) { handleReceive(ec, n); });
-}
-
-void srv::AsioServer::handleReceive(const asio::error_code &error, const std::size_t bytesTransferred)
-{
-    if (!error)
-    {
-        std::vector<uint8_t> data(m_recvBuffer.begin(), m_recvBuffer.begin() + bytesTransferred);
-        processPacket(m_remoteEndpoint, data);
-        startReceive();
-    }
-    else if (error == asio::error::operation_aborted)
-    {
-        return;
-    }
-    else
-    {
-        std::cerr << "[AsioServer] Erreur de réception: " << error.message() << "\n";
-        startReceive();
-    }
-}
-
-void srv::AsioServer::handleSend(const asio::error_code &error, std::size_t bytesTransferred)
-{
-    if (error)
-    {
-        std::cerr << "[AsioServer] Erreur d'envoi: " << error.message() << "\n";
-    }
-}
-
-void srv::AsioServer::processPacket(const asio::ip::udp::endpoint &sender, const std::vector<uint8_t> &data)
-{
-    try
-    {
-        rnp::PacketHeader header = rnp::deserializeHeader(data.data(), data.size());
-
-        std::vector<uint8_t> payload;
-        if (header.length > 0 && data.size() >= 16 + header.length)
-        {
-            payload.assign(data.begin() + 16, data.begin() + 16 + header.length);
+            utl::Logger::log("AsioServer: Already started", utl::LogLevel::WARNING);
+            return;
         }
 
-        // Vérifier la session ID (sauf pour CONNECT)
-        if (static_cast<rnp::PacketType>(header.type) != rnp::PacketType::CONNECT)
+        try
         {
-            auto it = m_clients.find(sender);
-            if (it != m_clients.end() && it->second.sessionId != header.sessionId)
+            utl::Logger::log("AsioServer: Creating endpoint for " + m_host + ":" + std::to_string(m_port),
+                             utl::LogLevel::INFO);
+
+            // Create endpoint
+            asio::ip::udp::endpoint endpoint(asio::ip::make_address(m_host), m_port);
+            utl::Logger::log("AsioServer: Endpoint created successfully", utl::LogLevel::INFO);
+
+            // Bind socket
+            utl::Logger::log("AsioServer: Opening socket...", utl::LogLevel::INFO);
+            m_socket->open(endpoint.protocol());
+            utl::Logger::log("AsioServer: Setting socket options...", utl::LogLevel::INFO);
+            m_socket->set_option(asio::ip::udp::socket::reuse_address(true));
+            utl::Logger::log("AsioServer: Binding socket to endpoint...", utl::LogLevel::INFO);
+            m_socket->bind(endpoint);
+            utl::Logger::log("AsioServer: Socket bound successfully", utl::LogLevel::INFO);
+
+            m_running.store(true);
+            m_started.store(true);
+
+            // Start network thread
+            utl::Logger::log("AsioServer: Starting network thread...", utl::LogLevel::INFO);
+            m_networkThread = std::make_unique<std::thread>(&AsioServer::networkThreadLoop, this);
+
+            // Start receiving
+            utl::Logger::log("AsioServer: Starting packet reception...", utl::LogLevel::INFO);
+            startReceive();
+
+            utl::Logger::log("AsioServer: Started on " + m_host + ":" + std::to_string(m_port), utl::LogLevel::INFO);
+        }
+        catch (const std::exception &e)
+        {
+            m_running.store(false);
+            m_started.store(false);
+            utl::Logger::log("AsioServer: Failed to start - " + std::string(e.what()), utl::LogLevel::WARNING);
+            throw;
+        }
+    }
+
+    void AsioServer::stop()
+    {
+        if (!m_started.load())
+        {
+            return;
+        }
+
+        m_running.store(false);
+        m_started.store(false);
+
+        // Send disconnect to all clients
+        {
+            std::lock_guard<std::mutex> lock(m_clientsMutex);
+            for (auto &[sessionId, client] : m_clients)
             {
-                sendError(sender, rnp::ErrorCode::UNAUTHORIZED_SESSION, "Invalid session ID");
-                return;
+                if (client.isConnected)
+                {
+                    rnp::Serializer serializer;
+                    rnp::PacketHeader header{};
+                    header.type = static_cast<std::uint8_t>(rnp::PacketType::DISCONNECT);
+                    header.length = sizeof(rnp::PacketDisconnect);
+                    header.flags = 0;
+                    header.sessionId = sessionId;
+
+                    rnp::PacketDisconnect disconnect{};
+                    disconnect.reasonCode = static_cast<std::uint16_t>(rnp::DisconnectReason::SERVER_SHUTDOWN);
+
+                    serializer.serializeHeader(header);
+                    serializer.serializeDisconnect(disconnect);
+
+                    sendPacketImmediate(serializer.getData(), client.endpoint);
+                }
             }
         }
 
-        // Gérer les flags de fiabilité
-        if (header.flags & static_cast<std::uint16_t>(rnp::PacketFlags::RELIABLE))
+        // Stop io_context safely
+        if (m_ioContext)
         {
-            handleReliablePacket(sender, header);
-        }
-        if (header.flags & static_cast<std::uint16_t>(rnp::PacketFlags::ACK_REQ))
-        {
-            sendAck(sender, header.sequence, 0);
+            m_ioContext->stop();
         }
 
-        switch (static_cast<rnp::PacketType>(header.type))
+        // Wait for network thread with timeout
+        if (m_networkThread && m_networkThread->joinable())
         {
-            case rnp::PacketType::CONNECT:
-            {
-                if (payload.size() >= 5)
-                {
-                    std::uint8_t nameLen = payload[0];
-                    if (payload.size() >= 1 + nameLen + 4)
-                    {
-                        std::string playerName(payload.begin() + 1, payload.begin() + 1 + nameLen);
-                        std::uint32_t clientCaps = (static_cast<std::uint32_t>(payload[1 + nameLen]) << 24) |
-                                                   (static_cast<std::uint32_t>(payload[1 + nameLen + 1]) << 16) |
-                                                   (static_cast<std::uint32_t>(payload[1 + nameLen + 2]) << 8) |
-                                                   static_cast<std::uint32_t>(payload[1 + nameLen + 3]);
+            auto joinStart = std::chrono::steady_clock::now();
+            bool joined = false;
 
-                        std::uint32_t sessionId = m_nextSessionId++;
-                        addClient(sender, playerName, clientCaps, sessionId);
-                        sendConnectAccept(sender, sessionId);
-                        std::cout << "[AsioServer] Client connecté: " << playerName << " ("
-                                  << sender.address().to_string() << ":" << sender.port()
-                                  << ") - Session: " << sessionId << "\n";
-                    }
-                }
-                break;
-            }
-            case rnp::PacketType::DISCONNECT:
+            while (
+                !joined &&
+                std::chrono::duration_cast<std::chrono::seconds>(std::chrono::steady_clock::now() - joinStart).count() <
+                    5)
             {
-                if (payload.size() >= 2)
+                if (m_networkThread->joinable())
                 {
-                    std::uint16_t reason =
-                        (static_cast<std::uint16_t>(payload[0]) << 8) | static_cast<std::uint16_t>(payload[1]);
-                    std::cout << "[AsioServer] Client déconnecté: " << sender.address().to_string() << ":"
-                              << sender.port() << " - Reason: " << reason << "\n";
-                }
-                removeClient(sender);
-                break;
-            }
-            case rnp::PacketType::ACK:
-            {
-                processAck(sender, payload);
-                break;
-            }
-            case rnp::PacketType::ENTITY_EVENT:
-            {
-                try
-                {
-                    const std::vector<rnp::EventRecord> events = rnp::deserializeEvents(payload.data(), payload.size());
-
-                    // Broadcast les events aux autres clients
-                    for (const auto &[endpoint, clientInfo] : m_clients)
-                    {
-                        if (endpoint != sender && clientInfo.connected)
-                        {
-                            sendEntityEvent(endpoint, 0, events);
-                        }
-                    }
-                }
-                catch (const std::exception &e)
-                {
-                    std::cerr << "[AsioServer] Erreur parsing ENTITY_EVENT: " << e.what() << "\n";
-                }
-                break;
-            }
-            case rnp::PacketType::PLAYER_INPUT:
-            {
-                // Support legacy PLAYER_INPUT
-                if (payload.size() >= 2)
-                {
-                    const std::uint8_t direction = payload[0];
-                    const std::uint8_t shooting = payload[1];
-
-                    rnp::EventRecord ev;
-                    ev.type = rnp::EventType::INPUT;
-                    ev.entityId = getPlayerId(sender);
-                    ev.data.reserve(4);
-
-                    const std::uint16_t playerId = getPlayerId(sender);
-                    ev.data.push_back(static_cast<std::uint8_t>(playerId & 0xFF));
-                    ev.data.push_back(static_cast<std::uint8_t>((playerId >> 8) & 0xFF));
-                    ev.data.push_back(direction);
-                    ev.data.push_back(shooting);
-
-                    std::vector<rnp::EventRecord> batch;
-                    batch.emplace_back(std::move(ev));
-                    broadcastEvents(batch);
-                }
-                break;
-            }
-            case rnp::PacketType::PING:
-            {
-                if (payload.size() >= 8)
-                {
-                    std::uint32_t nonce = (static_cast<std::uint32_t>(payload[0]) << 24) |
-                                          (static_cast<std::uint32_t>(payload[1]) << 16) |
-                                          (static_cast<std::uint32_t>(payload[2]) << 8) |
-                                          static_cast<std::uint32_t>(payload[3]);
-                    std::uint32_t sendTime = (static_cast<std::uint32_t>(payload[4]) << 24) |
-                                             (static_cast<std::uint32_t>(payload[5]) << 16) |
-                                             (static_cast<std::uint32_t>(payload[6]) << 8) |
-                                             static_cast<std::uint32_t>(payload[7]);
-                    sendPong(sender, nonce, sendTime);
+                    m_networkThread->join();
+                    joined = true;
                 }
                 else
                 {
-                    sendPong(sender);
+                    std::this_thread::sleep_for(std::chrono::milliseconds(10));
                 }
-                break;
             }
-            default:
-                break;
-        }
 
-        auto it = m_packetHandlers.find(static_cast<rnp::PacketType>(header.type));
-        if (it != m_packetHandlers.end())
-        {
-            it->second(sender, header, payload);
-        }
-    }
-    catch (const std::exception &e)
-    {
-        std::cerr << "[AsioServer] Erreur de traitement du paquet: " << e.what() << "\n";
-        sendError(sender, rnp::ErrorCode::INVALID_PAYLOAD, "Erreur de traitement du paquet");
-    }
-}
-
-void srv::AsioServer::addClient(const asio::ip::udp::endpoint &endpoint, const std::string &playerName,
-                                std::uint32_t clientCaps, std::uint32_t sessionId)
-{
-    ClientInfo info;
-    info.endpoint = endpoint;
-    info.playerName = playerName;
-    info.lastSequence = 0;
-    info.connected = true;
-    info.playerId = m_nextPlayerId++;
-    info.sessionId = sessionId;
-    info.clientCaps = clientCaps;
-    m_clients[endpoint] = info;
-}
-
-void srv::AsioServer::removeClient(const asio::ip::udp::endpoint &endpoint) { m_clients.erase(endpoint); }
-
-std::uint16_t srv::AsioServer::getPlayerId(const asio::ip::udp::endpoint &endpoint) const
-{
-    auto it = m_clients.find(endpoint);
-    if (it != m_clients.end())
-    {
-        return it->second.playerId;
-    }
-    return 0;
-}
-
-std::uint32_t srv::AsioServer::getSessionId(const asio::ip::udp::endpoint &endpoint) const
-{
-    auto it = m_clients.find(endpoint);
-    if (it != m_clients.end())
-    {
-        return it->second.sessionId;
-    }
-    return 0;
-}
-
-void srv::AsioServer::sendConnectAccept(const asio::ip::udp::endpoint &client, std::uint32_t sessionId)
-{
-    rnp::PacketHeader header;
-    header.type = static_cast<std::uint8_t>(rnp::PacketType::CONNECT_ACCEPT);
-
-    // Payload: session_id(4, BE) | tick_rate_hz(2, BE) | mtu_payload_bytes(2, BE) | server_caps(4, BE)
-    std::vector<uint8_t> payload;
-
-    // session_id (4 bytes, big endian)
-    payload.push_back(static_cast<uint8_t>((sessionId >> 24) & 0xFF));
-    payload.push_back(static_cast<uint8_t>((sessionId >> 16) & 0xFF));
-    payload.push_back(static_cast<uint8_t>((sessionId >> 8) & 0xFF));
-    payload.push_back(static_cast<uint8_t>(sessionId & 0xFF));
-
-    // tick_rate_hz (2 bytes, big endian)
-    payload.push_back(static_cast<uint8_t>((m_tickRateHz >> 8) & 0xFF));
-    payload.push_back(static_cast<uint8_t>(m_tickRateHz & 0xFF));
-
-    // mtu_payload_bytes (2 bytes, big endian)
-    payload.push_back(static_cast<uint8_t>((m_mtuPayloadBytes >> 8) & 0xFF));
-    payload.push_back(static_cast<uint8_t>(m_mtuPayloadBytes & 0xFF));
-
-    // server_caps (4 bytes, big endian)
-    payload.push_back(static_cast<uint8_t>((m_serverCaps >> 24) & 0xFF));
-    payload.push_back(static_cast<uint8_t>((m_serverCaps >> 16) & 0xFF));
-    payload.push_back(static_cast<uint8_t>((m_serverCaps >> 8) & 0xFF));
-    payload.push_back(static_cast<uint8_t>(m_serverCaps & 0xFF));
-
-    header.length = payload.size();
-    header.flags =
-        static_cast<std::uint16_t>(rnp::PacketFlags::RELIABLE) | static_cast<std::uint16_t>(rnp::PacketFlags::ACK_REQ);
-    header.reserved = 0;
-    header.sequence = ++m_sequenceNumber;
-    header.sessionId = sessionId;
-
-    std::vector<uint8_t> buffer = rnp::serialize(header, payload.data());
-
-    m_socket.async_send_to(asio::buffer(buffer), client,
-                           [this](const asio::error_code &error, std::size_t bytesTransferred)
-                           { handleSend(error, bytesTransferred); });
-}
-
-void srv::AsioServer::sendAck(const asio::ip::udp::endpoint &client, std::uint32_t cumulative, std::uint32_t ackBits)
-{
-    rnp::PacketHeader header;
-    header.type = static_cast<std::uint8_t>(rnp::PacketType::ACK);
-
-    // Payload: cumulative_ack(4, BE) | ack_bits(4, BE)
-    std::vector<uint8_t> payload;
-
-    // cumulative_ack (4 bytes, big endian)
-    payload.push_back(static_cast<uint8_t>((cumulative >> 24) & 0xFF));
-    payload.push_back(static_cast<uint8_t>((cumulative >> 16) & 0xFF));
-    payload.push_back(static_cast<uint8_t>((cumulative >> 8) & 0xFF));
-    payload.push_back(static_cast<uint8_t>(cumulative & 0xFF));
-
-    // ack_bits (4 bytes, big endian)
-    payload.push_back(static_cast<uint8_t>((ackBits >> 24) & 0xFF));
-    payload.push_back(static_cast<uint8_t>((ackBits >> 16) & 0xFF));
-    payload.push_back(static_cast<uint8_t>((ackBits >> 8) & 0xFF));
-    payload.push_back(static_cast<uint8_t>(ackBits & 0xFF));
-
-    header.length = payload.size();
-    header.flags = 0;
-    header.reserved = 0;
-    header.sequence = ++m_sequenceNumber;
-    header.sessionId = getSessionId(client);
-
-    std::vector<uint8_t> buffer = rnp::serialize(header, payload.data());
-
-    m_socket.async_send_to(asio::buffer(buffer), client,
-                           [this](const asio::error_code &error, std::size_t bytesTransferred)
-                           { handleSend(error, bytesTransferred); });
-}
-
-void srv::AsioServer::sendWorldState(const asio::ip::udp::endpoint &client, const std::vector<uint8_t> &worldData)
-{
-    rnp::PacketHeader header;
-    header.type = static_cast<std::uint8_t>(rnp::PacketType::WORLD_STATE);
-    header.length = worldData.size();
-    header.flags = 0;
-    header.reserved = 0;
-    header.sequence = ++m_sequenceNumber;
-    header.sessionId = getSessionId(client);
-
-    std::vector<uint8_t> buffer = rnp::serialize(header, worldData.data());
-
-    m_socket.async_send_to(asio::buffer(buffer), client,
-                           [this](const asio::error_code &error, std::size_t bytesTransferred)
-                           { handleSend(error, bytesTransferred); });
-}
-
-void srv::AsioServer::sendWorldState(const asio::ip::udp::endpoint &client, std::uint32_t serverTick,
-                                     const std::vector<rnp::EntityState> &entities)
-{
-    rnp::PacketHeader header;
-    header.type = static_cast<std::uint8_t>(rnp::PacketType::WORLD_STATE);
-
-    // Payload: server_tick(4, BE) | entity_count(2, BE) | entities...
-    std::vector<uint8_t> payload;
-
-    // server_tick (4 bytes, big endian)
-    payload.push_back(static_cast<uint8_t>((serverTick >> 24) & 0xFF));
-    payload.push_back(static_cast<uint8_t>((serverTick >> 16) & 0xFF));
-    payload.push_back(static_cast<uint8_t>((serverTick >> 8) & 0xFF));
-    payload.push_back(static_cast<uint8_t>(serverTick & 0xFF));
-
-    // entity_count (2 bytes, big endian)
-    std::uint16_t entityCount = static_cast<std::uint16_t>(entities.size());
-    payload.push_back(static_cast<uint8_t>((entityCount >> 8) & 0xFF));
-    payload.push_back(static_cast<uint8_t>(entityCount & 0xFF));
-
-    // Pour chaque entité: id(4) | type(2) | x(4) | y(4) | vx(4) | vy(4) | state_flags(1)
-    for (const auto &entity : entities)
-    {
-        // id (4 bytes, big endian)
-        payload.push_back(static_cast<uint8_t>((entity.id >> 24) & 0xFF));
-        payload.push_back(static_cast<uint8_t>((entity.id >> 16) & 0xFF));
-        payload.push_back(static_cast<uint8_t>((entity.id >> 8) & 0xFF));
-        payload.push_back(static_cast<uint8_t>(entity.id & 0xFF));
-
-        // type (2 bytes, big endian)
-        payload.push_back(static_cast<uint8_t>((entity.type >> 8) & 0xFF));
-        payload.push_back(static_cast<uint8_t>(entity.type & 0xFF));
-
-        // x, y, vx, vy (floats en big endian)
-        const uint8_t *xBytes = reinterpret_cast<const uint8_t *>(&entity.x);
-        const uint8_t *yBytes = reinterpret_cast<const uint8_t *>(&entity.y);
-        const uint8_t *vxBytes = reinterpret_cast<const uint8_t *>(&entity.vx);
-        const uint8_t *vyBytes = reinterpret_cast<const uint8_t *>(&entity.vy);
-
-        // Note: Assuming little endian system, reverse for big endian network order
-        for (int i = 3; i >= 0; --i)
-            payload.push_back(xBytes[i]);
-        for (int i = 3; i >= 0; --i)
-            payload.push_back(yBytes[i]);
-        for (int i = 3; i >= 0; --i)
-            payload.push_back(vxBytes[i]);
-        for (int i = 3; i >= 0; --i)
-            payload.push_back(vyBytes[i]);
-
-        // state_flags (1 byte)
-        payload.push_back(entity.stateFlags);
-    }
-
-    header.length = payload.size();
-    header.flags = 0;
-    header.reserved = 0;
-    header.sequence = ++m_sequenceNumber;
-    header.sessionId = getSessionId(client);
-
-    std::vector<uint8_t> buffer = rnp::serialize(header, payload.data());
-
-    m_socket.async_send_to(asio::buffer(buffer), client,
-                           [this](const asio::error_code &error, std::size_t bytesTransferred)
-                           { handleSend(error, bytesTransferred); });
-}
-
-void srv::AsioServer::sendEvents(const asio::ip::udp::endpoint &client, const std::vector<rnp::EventRecord> &events)
-{
-    const std::vector<uint8_t> eventsPayload = rnp::serializeEvents(events);
-
-    rnp::PacketHeader header;
-    header.type = static_cast<std::uint8_t>(rnp::PacketType::ENTITY_EVENT);
-    header.length = static_cast<std::uint16_t>(eventsPayload.size());
-    header.flags = 0;
-    header.reserved = 0;
-    header.sequence = ++m_sequenceNumber;
-    header.sessionId = getSessionId(client);
-
-    std::vector<uint8_t> buffer = rnp::serialize(header, eventsPayload.data());
-
-    m_socket.async_send_to(asio::buffer(buffer), client,
-                           [this](const asio::error_code &error, std::size_t bytesTransferred)
-                           { handleSend(error, bytesTransferred); });
-}
-
-void srv::AsioServer::sendEntityEvent(const asio::ip::udp::endpoint &client, std::uint32_t serverTick,
-                                      const std::vector<rnp::EventRecord> &events)
-{
-    const std::vector<uint8_t> eventsPayload = rnp::serializeEvents(events);
-
-    // Payload: server_tick(4, BE) | event_count(2, BE) | events...
-    std::vector<uint8_t> payload;
-
-    // server_tick (4 bytes, big endian)
-    payload.push_back(static_cast<uint8_t>((serverTick >> 24) & 0xFF));
-    payload.push_back(static_cast<uint8_t>((serverTick >> 16) & 0xFF));
-    payload.push_back(static_cast<uint8_t>((serverTick >> 8) & 0xFF));
-    payload.push_back(static_cast<uint8_t>(serverTick & 0xFF));
-
-    // event_count (2 bytes, big endian)
-    std::uint16_t eventCount = static_cast<std::uint16_t>(events.size());
-    payload.push_back(static_cast<uint8_t>((eventCount >> 8) & 0xFF));
-    payload.push_back(static_cast<uint8_t>(eventCount & 0xFF));
-
-    // Events serialized
-    payload.insert(payload.end(), eventsPayload.begin(), eventsPayload.end());
-
-    rnp::PacketHeader header;
-    header.type = static_cast<std::uint8_t>(rnp::PacketType::ENTITY_EVENT);
-    header.length = static_cast<std::uint16_t>(payload.size());
-    header.flags = 0;
-    header.reserved = 0;
-    header.sequence = ++m_sequenceNumber;
-    header.sessionId = getSessionId(client);
-
-    std::vector<uint8_t> buffer = rnp::serialize(header, payload.data());
-
-    m_socket.async_send_to(asio::buffer(buffer), client,
-                           [this](const asio::error_code &error, std::size_t bytesTransferred)
-                           { handleSend(error, bytesTransferred); });
-}
-
-void srv::AsioServer::sendPong(const asio::ip::udp::endpoint &client)
-{
-    rnp::PacketHeader header;
-    header.type = static_cast<std::uint8_t>(rnp::PacketType::PONG);
-    header.length = 0;
-    header.flags = 0;
-    header.reserved = 0;
-    header.sequence = ++m_sequenceNumber;
-    header.sessionId = getSessionId(client);
-
-    std::vector<uint8_t> buffer = rnp::serialize(header);
-
-    m_socket.async_send_to(asio::buffer(buffer), client,
-                           [this](const asio::error_code &error, std::size_t bytesTransferred)
-                           { handleSend(error, bytesTransferred); });
-}
-
-void srv::AsioServer::sendPong(const asio::ip::udp::endpoint &client, std::uint32_t nonce, std::uint32_t sendTimeMs)
-{
-    rnp::PacketHeader header;
-    header.type = static_cast<std::uint8_t>(rnp::PacketType::PONG);
-
-    // Payload: nonce(4, BE) | send_time_ms(4, BE)
-    std::vector<uint8_t> payload;
-
-    // nonce (4 bytes, big endian)
-    payload.push_back(static_cast<uint8_t>((nonce >> 24) & 0xFF));
-    payload.push_back(static_cast<uint8_t>((nonce >> 16) & 0xFF));
-    payload.push_back(static_cast<uint8_t>((nonce >> 8) & 0xFF));
-    payload.push_back(static_cast<uint8_t>(nonce & 0xFF));
-
-    // send_time_ms (4 bytes, big endian)
-    payload.push_back(static_cast<uint8_t>((sendTimeMs >> 24) & 0xFF));
-    payload.push_back(static_cast<uint8_t>((sendTimeMs >> 16) & 0xFF));
-    payload.push_back(static_cast<uint8_t>((sendTimeMs >> 8) & 0xFF));
-    payload.push_back(static_cast<uint8_t>(sendTimeMs & 0xFF));
-
-    header.length = payload.size();
-    header.flags = 0;
-    header.reserved = 0;
-    header.sequence = ++m_sequenceNumber;
-    header.sessionId = getSessionId(client);
-
-    std::vector<uint8_t> buffer = rnp::serialize(header, payload.data());
-
-    m_socket.async_send_to(asio::buffer(buffer), client,
-                           [this](const asio::error_code &error, std::size_t bytesTransferred)
-                           { handleSend(error, bytesTransferred); });
-}
-
-void srv::AsioServer::sendError(const asio::ip::udp::endpoint &client, const std::string &errorMessage)
-{
-    sendError(client, rnp::ErrorCode::INTERNAL_ERROR, errorMessage);
-}
-
-void srv::AsioServer::sendError(const asio::ip::udp::endpoint &client, rnp::ErrorCode errorCode,
-                                const std::string &errorMessage)
-{
-    rnp::PacketHeader header;
-    header.type = static_cast<std::uint8_t>(rnp::PacketType::PACKET_ERROR);
-
-    // Payload: error_code(2, BE) | msg_len(2, BE) | message
-    std::vector<uint8_t> payload;
-    std::uint16_t code = static_cast<std::uint16_t>(errorCode);
-    payload.push_back(static_cast<uint8_t>((code >> 8) & 0xFF));
-    payload.push_back(static_cast<uint8_t>(code & 0xFF));
-
-    std::uint16_t msgLen = static_cast<std::uint16_t>(errorMessage.size());
-    payload.push_back(static_cast<uint8_t>((msgLen >> 8) & 0xFF));
-    payload.push_back(static_cast<uint8_t>(msgLen & 0xFF));
-
-    payload.insert(payload.end(), errorMessage.begin(), errorMessage.end());
-
-    header.length = payload.size();
-    header.flags = 0;
-    header.reserved = 0;
-    header.sequence = ++m_sequenceNumber;
-    header.sessionId = getSessionId(client);
-
-    std::vector<uint8_t> buffer = rnp::serialize(header, payload.data());
-
-    m_socket.async_send_to(asio::buffer(buffer), client,
-                           [this](const asio::error_code &error, std::size_t bytesTransferred)
-                           { handleSend(error, bytesTransferred); });
-}
-
-void srv::AsioServer::broadcastToAll(const std::vector<uint8_t> &data)
-{
-    for (const auto &[endpoint, clientInfo] : m_clients)
-    {
-        if (clientInfo.connected)
-        {
-            m_socket.async_send_to(asio::buffer(data), endpoint,
-                                   [this](const asio::error_code &error, std::size_t bytesTransferred)
-                                   { handleSend(error, bytesTransferred); });
-        }
-    }
-}
-
-void srv::AsioServer::broadcastEvents(const std::vector<rnp::EventRecord> &events)
-{
-    const std::vector<uint8_t> payload = rnp::serializeEvents(events);
-
-    rnp::PacketHeader header;
-    header.type = static_cast<std::uint8_t>(rnp::PacketType::ENTITY_EVENT);
-    header.length = static_cast<std::uint16_t>(payload.size());
-    header.flags = 0;
-    header.reserved = 0;
-    header.sequence = ++m_sequenceNumber;
-
-    for (const auto &[endpoint, clientInfo] : m_clients)
-    {
-        if (clientInfo.connected)
-        {
-            header.sessionId = clientInfo.sessionId;
-            const std::vector<uint8_t> frame = rnp::serialize(header, payload.data());
-
-            m_socket.async_send_to(asio::buffer(frame), endpoint,
-                                   [this](const asio::error_code &error, std::size_t bytesTransferred)
-                                   { handleSend(error, bytesTransferred); });
-        }
-    }
-}
-
-void srv::AsioServer::broadcastEntityEvents(std::uint32_t serverTick, const std::vector<rnp::EventRecord> &events)
-{
-    const std::vector<uint8_t> eventsPayload = rnp::serializeEvents(events);
-
-    // Payload: server_tick(4, BE) | event_count(2, BE) | events...
-    std::vector<uint8_t> payload;
-
-    // server_tick (4 bytes, big endian)
-    payload.push_back(static_cast<uint8_t>((serverTick >> 24) & 0xFF));
-    payload.push_back(static_cast<uint8_t>((serverTick >> 16) & 0xFF));
-    payload.push_back(static_cast<uint8_t>((serverTick >> 8) & 0xFF));
-    payload.push_back(static_cast<uint8_t>(serverTick & 0xFF));
-
-    // event_count (2 bytes, big endian)
-    std::uint16_t eventCount = static_cast<std::uint16_t>(events.size());
-    payload.push_back(static_cast<uint8_t>((eventCount >> 8) & 0xFF));
-    payload.push_back(static_cast<uint8_t>(eventCount & 0xFF));
-
-    // Events serialized
-    payload.insert(payload.end(), eventsPayload.begin(), eventsPayload.end());
-
-    rnp::PacketHeader header;
-    header.type = static_cast<std::uint8_t>(rnp::PacketType::ENTITY_EVENT);
-    header.length = static_cast<std::uint16_t>(payload.size());
-    header.flags = 0;
-    header.reserved = 0;
-    header.sequence = ++m_sequenceNumber;
-
-    for (const auto &[endpoint, clientInfo] : m_clients)
-    {
-        if (clientInfo.connected)
-        {
-            header.sessionId = clientInfo.sessionId;
-            const std::vector<uint8_t> frame = rnp::serialize(header, payload.data());
-
-            m_socket.async_send_to(asio::buffer(frame), endpoint,
-                                   [this](const asio::error_code &error, std::size_t bytesTransferred)
-                                   { handleSend(error, bytesTransferred); });
-        }
-    }
-}
-
-void srv::AsioServer::setPacketHandler(rnp::PacketType type, PacketHandler handler)
-{
-    m_packetHandlers[type] = handler;
-}
-
-void srv::AsioServer::handleReliablePacket(const asio::ip::udp::endpoint &sender, const rnp::PacketHeader &header)
-{
-    // Store for potential retransmission (simplified implementation)
-    // In production, you'd want more sophisticated tracking
-    auto it = m_clients.find(sender);
-    if (it != m_clients.end())
-    {
-        it->second.lastSequence = header.sequence;
-    }
-}
-
-void srv::AsioServer::processAck(const asio::ip::udp::endpoint &sender, const std::vector<uint8_t> &payload)
-{
-    if (payload.size() < 8)
-    {
-        return;
-    }
-
-    // cumulative_ack (4 bytes, big endian)
-    std::uint32_t cumulative = (static_cast<std::uint32_t>(payload[0]) << 24) |
-                               (static_cast<std::uint32_t>(payload[1]) << 16) |
-                               (static_cast<std::uint32_t>(payload[2]) << 8) | static_cast<std::uint32_t>(payload[3]);
-
-    // ack_bits (4 bytes, big endian)
-    std::uint32_t ackBits = (static_cast<std::uint32_t>(payload[4]) << 24) |
-                            (static_cast<std::uint32_t>(payload[5]) << 16) |
-                            (static_cast<std::uint32_t>(payload[6]) << 8) | static_cast<std::uint32_t>(payload[7]);
-
-    // Remove acknowledged packets from pending reliable
-    m_pendingReliable.erase(cumulative);
-
-    // Process ack bits for selective acknowledgment
-    for (int i = 0; i < 32; ++i)
-    {
-        if (ackBits & (1 << i))
-        {
-            m_pendingReliable.erase(cumulative - i - 1);
-        }
-    }
-
-    m_clientLastAck[sender] = cumulative;
-}
-
-void srv::AsioServer::retransmitReliable()
-{
-    // Simplified retransmission logic
-    // In production, track timestamps and implement exponential backoff
-    for (const auto &[seq, data] : m_pendingReliable)
-    {
-        // Retransmit to all clients (would need per-client tracking in production)
-        for (const auto &[endpoint, clientInfo] : m_clients)
-        {
-            if (clientInfo.connected)
+            if (!joined)
             {
-                m_socket.async_send_to(asio::buffer(data), endpoint,
-                                       [this](const asio::error_code &error, std::size_t bytesTransferred)
-                                       { handleSend(error, bytesTransferred); });
+                utl::Logger::log("AsioServer: Network thread join timeout, detaching", utl::LogLevel::WARNING);
+                m_networkThread->detach();
+            }
+        }
+
+        // Close socket safely
+        {
+            std::lock_guard<std::mutex> socketLock(m_socketMutex);
+            if (m_socket && m_socket->is_open())
+            {
+                try
+                {
+                    m_socket->close();
+                }
+                catch (const std::exception &e)
+                {
+                    utl::Logger::log("AsioServer: Exception closing socket - " + std::string(e.what()),
+                                     utl::LogLevel::WARNING);
+                }
+            }
+        }
+
+        // Clear clients
+        {
+            std::lock_guard<std::mutex> lock(m_clientsMutex);
+            m_clients.clear();
+            m_endpointToSession.clear();
+        }
+
+        utl::Logger::log("AsioServer: Stopped", utl::LogLevel::INFO);
+    }
+
+    void AsioServer::update()
+    {
+        if (!m_running.load())
+        {
+            static bool loggedNotRunning = false;
+            if (!loggedNotRunning)
+            {
+                utl::Logger::log("AsioServer: Update called but server not running", utl::LogLevel::WARNING);
+                loggedNotRunning = true;
+            }
+            return;
+        }
+
+        // Process send queue
+        processSendQueue();
+
+        // Update client management (timeouts, pings)
+        updateClientManagement();
+    }
+
+    void AsioServer::sendToClient(std::uint32_t sessionId, const std::vector<std::uint8_t> &data, bool reliable)
+    {
+        std::lock_guard<std::mutex> clientLock(m_clientsMutex);
+        auto it = m_clients.find(sessionId);
+        if (it == m_clients.end() || !it->second.isConnected)
+        {
+            utl::Logger::log("AsioServer: Attempted to send to invalid session " + std::to_string(sessionId),
+                             utl::LogLevel::WARNING);
+            return;
+        }
+
+        std::lock_guard<std::mutex> queueLock(m_sendQueueMutex);
+        m_sendQueue.emplace(data, it->second.endpoint, reliable);
+    }
+
+    void AsioServer::sendToAllClients(const std::vector<std::uint8_t> &data, bool reliable)
+    {
+        std::lock_guard<std::mutex> clientLock(m_clientsMutex);
+        std::lock_guard<std::mutex> queueLock(m_sendQueueMutex);
+
+        for (const auto &[sessionId, client] : m_clients)
+        {
+            if (client.isConnected)
+            {
+                m_sendQueue.emplace(data, client.endpoint, reliable);
             }
         }
     }
-}
+
+    void AsioServer::disconnectClient(std::uint32_t sessionId)
+    {
+        std::lock_guard<std::mutex> lock(m_clientsMutex);
+        auto it = m_clients.find(sessionId);
+        if (it == m_clients.end())
+        {
+            return;
+        }
+
+        // Send disconnect packet
+        rnp::Serializer serializer;
+        rnp::PacketHeader header{};
+        header.type = static_cast<std::uint8_t>(rnp::PacketType::DISCONNECT);
+        header.length = sizeof(rnp::PacketDisconnect);
+        header.flags = 0;
+        header.sessionId = sessionId;
+
+        rnp::PacketDisconnect disconnect{};
+        disconnect.reasonCode = static_cast<std::uint16_t>(rnp::DisconnectReason::CLIENT_REQUEST);
+
+        serializer.serializeHeader(header);
+        serializer.serializeDisconnect(disconnect);
+
+        sendPacketImmediate(serializer.getData(), it->second.endpoint);
+
+        // Remove from endpoint mapping
+        std::string endpointStr = endpointToString(it->second.endpoint);
+        m_endpointToSession.erase(endpointStr);
+
+        // Remove client
+        m_clients.erase(it);
+
+        m_packetHandler->clearSession(sessionId);
+
+        utl::Logger::log("AsioServer: Disconnected client " + std::to_string(sessionId), utl::LogLevel::INFO);
+    }
+
+    std::size_t AsioServer::getClientCount() const
+    {
+        std::lock_guard<std::mutex> clientLock(m_clientsMutex);
+        return std::count_if(m_clients.begin(), m_clients.end(),
+                             [](const auto &pair) { return pair.second.isConnected; });
+    }
+
+    std::vector<std::uint32_t> AsioServer::getConnectedSessions() const
+    {
+        std::lock_guard<std::mutex> clientLock(m_clientsMutex);
+        std::vector<std::uint32_t> sessions;
+        for (const auto &[sessionId, client] : m_clients)
+        {
+            if (client.isConnected)
+            {
+                sessions.push_back(sessionId);
+            }
+        }
+        return sessions;
+    }
+
+    bool AsioServer::isRunning() const { return m_running.load(); }
+
+    void AsioServer::setTickRate(std::uint16_t tickRate)
+    {
+        m_tickRate = tickRate;
+        utl::Logger::log("AsioServer: Tick rate set to " + std::to_string(tickRate), utl::LogLevel::INFO);
+    }
+
+    void AsioServer::setServerCapabilities(std::uint32_t caps)
+    {
+        m_serverCaps = caps;
+        utl::Logger::log("AsioServer: Server capabilities set to " + std::to_string(caps), utl::LogLevel::INFO);
+    }
+
+    void AsioServer::setupPacketHandlers()
+    {
+        // CONNECT handler
+        m_packetHandler->onConnect([this](const rnp::PacketConnect &packet, const rnp::PacketContext &context)
+                                   { return handleConnect(packet, context); });
+
+        // DISCONNECT handler
+        m_packetHandler->onDisconnect([this](const rnp::PacketDisconnect &packet, const rnp::PacketContext &context)
+                                      { return handleDisconnect(packet, context); });
+
+        // PING handler
+        m_packetHandler->onPing([this](const rnp::PacketPingPong &packet, const rnp::PacketContext &context)
+                                { return handlePing(packet, context); });
+
+        // PONG handler
+        m_packetHandler->onPong([this](const rnp::PacketPingPong &packet, const rnp::PacketContext &context)
+                                { return handlePong(packet, context); });
+
+        utl::Logger::log("AsioServer: Packet handlers initialized", utl::LogLevel::INFO);
+    }
+
+    void AsioServer::startReceive()
+    {
+        // Check if we should continue receiving
+        if (!m_running.load() || !m_socket || !m_socket->is_open())
+        {
+            utl::Logger::log("AsioServer: Cannot start receive - server not running or socket closed",
+                             utl::LogLevel::INFO);
+            return;
+        }
+
+        utl::Logger::log("AsioServer: Setting up async receive...", utl::LogLevel::INFO);
+        m_socket->async_receive_from(
+            asio::buffer(m_recvBuffer), m_senderEndpoint,
+            [this](std::error_code ec, std::size_t bytesReceived)
+            {
+                if (!ec && m_running.load())
+                {
+                    utl::Logger::log("AsioServer: Received " + std::to_string(bytesReceived) + " bytes from " +
+                                         m_senderEndpoint.address().to_string() + ":" +
+                                         std::to_string(m_senderEndpoint.port()),
+                                     utl::LogLevel::INFO);
+                    handleReceive(bytesReceived);
+                    startReceive(); // Continue receiving
+                }
+                else if (m_running.load() && ec != asio::error::operation_aborted)
+                {
+                    utl::Logger::log("AsioServer: Receive error - " + ec.message(), utl::LogLevel::WARNING);
+                    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+                    startReceive(); // Try to continue
+                }
+                else
+                {
+                    utl::Logger::log("AsioServer: Server stopped or operation aborted, ending receive loop",
+                                     utl::LogLevel::INFO);
+                }
+            });
+    }
+
+    void AsioServer::handleReceive(std::size_t bytesReceived)
+    {
+        utl::Logger::log("AsioServer: Processing received packet of " + std::to_string(bytesReceived) + " bytes",
+                         utl::LogLevel::INFO);
+
+        if (bytesReceived < sizeof(rnp::PacketHeader))
+        {
+            utl::Logger::log("AsioServer: Received packet too small (need " +
+                                 std::to_string(sizeof(rnp::PacketHeader)) + " bytes, got " +
+                                 std::to_string(bytesReceived) + ")",
+                             utl::LogLevel::WARNING);
+            return;
+        }
+
+        // Create packet context
+        rnp::PacketContext context;
+        context.receiveTime = std::chrono::steady_clock::now();
+        context.senderAddress = m_senderEndpoint.address().to_string();
+        context.senderPort = m_senderEndpoint.port();
+
+        utl::Logger::log("AsioServer: Packet from " + context.senderAddress + ":" + std::to_string(context.senderPort),
+                         utl::LogLevel::INFO);
+
+        // Extract session ID from header for context
+        std::vector<std::uint8_t> data(m_recvBuffer.begin(), m_recvBuffer.begin() + bytesReceived);
+        if (data.size() >= sizeof(rnp::PacketHeader))
+        {
+            rnp::Serializer headerSerializer(data);
+            rnp::PacketHeader header = headerSerializer.deserializeHeader();
+            context.sessionId = header.sessionId;
+            utl::Logger::log("AsioServer: Packet type: " + std::to_string(static_cast<int>(header.type)) +
+                                 ", Session ID: " + std::to_string(header.sessionId),
+                             utl::LogLevel::INFO);
+        }
+
+        // Process packet
+        utl::Logger::log("AsioServer: Processing packet...", utl::LogLevel::INFO);
+        rnp::HandlerResult result = m_packetHandler->processPacket(data, context);
+        if (result != rnp::HandlerResult::SUCCESS)
+        {
+            utl::Logger::log("AsioServer: Packet processing failed with result " +
+                                 std::to_string(static_cast<int>(result)),
+                             utl::LogLevel::WARNING);
+        }
+        else
+        {
+            utl::Logger::log("AsioServer: Packet processed successfully", utl::LogLevel::INFO);
+        }
+    }
+
+    void AsioServer::networkThreadLoop()
+    {
+        utl::Logger::log("AsioServer: Network thread started", utl::LogLevel::INFO);
+
+        while (m_running.load())
+        {
+            try
+            {
+                // Run I/O context and check if we should continue
+                if (!m_running.load())
+                {
+                    break;
+                }
+
+                size_t handlersRun = m_ioContext->run_one();
+                if (handlersRun == 0)
+                {
+                    // No handlers to run, sleep briefly to avoid busy waiting
+                    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+                }
+            }
+            catch (const std::exception &e)
+            {
+                if (m_running.load())
+                {
+                    utl::Logger::log("AsioServer: Network thread exception - " + std::string(e.what()),
+                                     utl::LogLevel::WARNING);
+                    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+                }
+            }
+        }
+
+        utl::Logger::log("AsioServer: Network thread stopped", utl::LogLevel::INFO);
+    }
+
+    std::uint32_t AsioServer::generateSessionId()
+    {
+        std::random_device rd;
+        std::mt19937 gen(rd());
+        std::uniform_int_distribution<std::uint32_t> dis(1, UINT32_MAX);
+
+        std::uint32_t sessionId = 0;
+        while (sessionId == 0 || m_clients.find(sessionId) != m_clients.end())
+        {
+            sessionId = dis(gen);
+        }
+
+        return sessionId;
+    }
+
+    std::string AsioServer::endpointToString(const asio::ip::udp::endpoint &endpoint) const
+    {
+        return endpoint.address().to_string() + ":" + std::to_string(endpoint.port());
+    }
+
+    void AsioServer::sendPacketImmediate(const std::vector<std::uint8_t> &data,
+                                         const asio::ip::udp::endpoint &destination)
+    {
+        utl::Logger::log("AsioServer: Sending " + std::to_string(data.size()) + " bytes to " +
+                             destination.address().to_string() + ":" + std::to_string(destination.port()),
+                         utl::LogLevel::INFO);
+
+        // Protect socket access with mutex
+        std::lock_guard<std::mutex> socketLock(m_socketMutex);
+
+        if (!m_socket || !m_socket->is_open() || !m_running.load())
+        {
+            utl::Logger::log("AsioServer: Cannot send - socket not open or server not running", utl::LogLevel::WARNING);
+            return;
+        }
+
+        try
+        {
+            size_t bytesSent = m_socket->send_to(asio::buffer(data), destination);
+            utl::Logger::log("AsioServer: Successfully sent " + std::to_string(bytesSent) + " bytes",
+                             utl::LogLevel::INFO);
+        }
+        catch (const std::exception &e)
+        {
+            if (m_running.load())
+            {
+                utl::Logger::log("AsioServer: Failed to send packet - " + std::string(e.what()),
+                                 utl::LogLevel::WARNING);
+            }
+        }
+    }
+
+    rnp::HandlerResult AsioServer::handleConnect(const rnp::PacketConnect &packet, const rnp::PacketContext &context)
+    {
+
+        utl::Logger::log("AsioServer: Handling CONNECT packet from " + context.senderAddress + ":" +
+                             std::to_string(context.senderPort),
+                         utl::LogLevel::INFO);
+
+        std::lock_guard<std::mutex> lock(m_clientsMutex);
+        // Check if server is full (avoid getClientCount() to prevent deadlock)
+        size_t currentClientCount =
+            std::count_if(m_clients.begin(), m_clients.end(), [](const auto &pair) { return pair.second.isConnected; });
+        utl::Logger::log("AsioServer: Current client count: " + std::to_string(currentClientCount) + "/" +
+                             std::to_string(MAX_CLIENTS),
+                         utl::LogLevel::INFO);
+
+        if (currentClientCount >= MAX_CLIENTS)
+        {
+            utl::Logger::log("AsioServer: Server full, rejecting connection", utl::LogLevel::WARNING);
+            sendError(rnp::ErrorCode::RATE_LIMITED, "Server full", m_senderEndpoint, 0);
+            return rnp::HandlerResult::SUCCESS;
+        }
+
+        // Check if client already exists
+        std::string endpointStr = endpointToString(m_senderEndpoint);
+        auto existingIt = m_endpointToSession.find(endpointStr);
+        if (existingIt != m_endpointToSession.end())
+        {
+            utl::Logger::log("AsioServer: Client already connected, resending accept (Session ID: " +
+                                 std::to_string(existingIt->second) + ")",
+                             utl::LogLevel::INFO);
+            // Client already connected, resend accept
+            sendConnectAccept(existingIt->second, m_senderEndpoint);
+            return rnp::HandlerResult::SUCCESS;
+        }
+
+        // Create new session
+        std::uint32_t sessionId = generateSessionId();
+        utl::Logger::log("AsioServer: Creating new session with ID: " + std::to_string(sessionId), utl::LogLevel::INFO);
+
+        ClientSession &client = m_clients[sessionId];
+        client.sessionId = sessionId;
+        client.endpoint = m_senderEndpoint;
+        client.lastSeen = context.receiveTime;
+        client.playerName = std::string(packet.playerName.data(), packet.nameLen);
+        client.clientCaps = packet.clientCaps;
+        client.isConnected = true;
+
+        m_endpointToSession[endpointStr] = sessionId;
+
+        utl::Logger::log("AsioServer: Player name: '" + client.playerName +
+                             "', Caps: " + std::to_string(client.clientCaps),
+                         utl::LogLevel::INFO);
+
+        // Send accept response
+        utl::Logger::log("AsioServer: Sending CONNECT_ACCEPT to session " + std::to_string(sessionId),
+                         utl::LogLevel::INFO);
+        sendConnectAccept(sessionId, m_senderEndpoint);
+
+        utl::Logger::log("AsioServer: Client connected - " + client.playerName + " (ID: " + std::to_string(sessionId) +
+                             ")",
+                         utl::LogLevel::INFO);
+
+        return rnp::HandlerResult::SUCCESS;
+    }
+
+    rnp::HandlerResult AsioServer::handleDisconnect(const rnp::PacketDisconnect &packet,
+                                                    const rnp::PacketContext &context)
+    {
+        utl::Logger::log("AsioServer: Handling DISCONNECT packet from session " + std::to_string(context.sessionId) +
+                             " from " + context.senderAddress + ":" + std::to_string(context.senderPort),
+                         utl::LogLevel::INFO);
+
+        std::lock_guard<std::mutex> lock(m_clientsMutex);
+
+        auto it = m_clients.find(context.sessionId);
+        if (it != m_clients.end())
+        {
+            utl::Logger::log("AsioServer: Client disconnected - " + it->second.playerName +
+                                 " (ID: " + std::to_string(context.sessionId) + ")" +
+                                 ", Reason: " + std::to_string(static_cast<int>(packet.reasonCode)),
+                             utl::LogLevel::INFO);
+
+            // Remove from endpoint mapping
+            std::string endpointStr = endpointToString(it->second.endpoint);
+            utl::Logger::log("AsioServer: Removing endpoint mapping: " + endpointStr, utl::LogLevel::INFO);
+            m_endpointToSession.erase(endpointStr);
+
+            // Remove client
+            utl::Logger::log("AsioServer: Removing client from session list", utl::LogLevel::INFO);
+            m_clients.erase(it);
+        }
+        else
+        {
+            utl::Logger::log("AsioServer: DISCONNECT from unknown session " + std::to_string(context.sessionId),
+                             utl::LogLevel::WARNING);
+        }
+
+        return rnp::HandlerResult::SUCCESS;
+    }
+
+    rnp::HandlerResult AsioServer::handlePing(const rnp::PacketPingPong &packet, const rnp::PacketContext &context)
+    {
+        utl::Logger::log("AsioServer: Handling PING from session " + std::to_string(context.sessionId) +
+                             " with nonce " + std::to_string(packet.nonce),
+                         utl::LogLevel::INFO);
+
+        // Update client last seen time
+        {
+            std::lock_guard<std::mutex> lock(m_clientsMutex);
+            auto it = m_clients.find(context.sessionId);
+            if (it != m_clients.end())
+            {
+                it->second.lastSeen = context.receiveTime;
+                utl::Logger::log("AsioServer: Updated last seen time for session " + std::to_string(context.sessionId),
+                                 utl::LogLevel::INFO);
+            }
+            else
+            {
+                utl::Logger::log("AsioServer: PING from unknown session " + std::to_string(context.sessionId),
+                                 utl::LogLevel::WARNING);
+            }
+        }
+
+        // Send pong response
+        utl::Logger::log("AsioServer: Sending PONG response to session " + std::to_string(context.sessionId),
+                         utl::LogLevel::INFO);
+        sendPong(packet.nonce, m_senderEndpoint, context.sessionId);
+        return rnp::HandlerResult::SUCCESS;
+    }
+
+    rnp::HandlerResult AsioServer::handlePong(const rnp::PacketPingPong &packet, const rnp::PacketContext &context)
+    {
+        utl::Logger::log("AsioServer: Handling PONG from session " + std::to_string(context.sessionId) +
+                             " with nonce " + std::to_string(packet.nonce),
+                         utl::LogLevel::INFO);
+
+        // Update client latency and last seen time
+        {
+            std::lock_guard<std::mutex> lock(m_clientsMutex);
+            auto it = m_clients.find(context.sessionId);
+            if (it != m_clients.end())
+            {
+                it->second.lastSeen = context.receiveTime;
+                // Calculate latency based on ping time
+                auto now = std::chrono::steady_clock::now();
+                auto pingTime = std::chrono::milliseconds(packet.sendTimeMs);
+                auto currentTime = std::chrono::duration_cast<std::chrono::milliseconds>(now.time_since_epoch());
+                it->second.latency = static_cast<std::uint32_t>((currentTime - pingTime).count());
+
+                utl::Logger::log("AsioServer: Updated client " + std::to_string(context.sessionId) +
+                                     " latency: " + std::to_string(it->second.latency) + "ms",
+                                 utl::LogLevel::INFO);
+            }
+            else
+            {
+                utl::Logger::log("AsioServer: PONG from unknown session " + std::to_string(context.sessionId),
+                                 utl::LogLevel::WARNING);
+            }
+        }
+
+        return rnp::HandlerResult::SUCCESS;
+    }
+
+    void AsioServer::sendPong(std::uint32_t nonce, const asio::ip::udp::endpoint &destination, std::uint32_t sessionId)
+    {
+        rnp::Serializer serializer;
+        rnp::PacketHeader header{};
+        header.type = static_cast<std::uint8_t>(rnp::PacketType::PONG);
+        header.length = sizeof(rnp::PacketPingPong);
+        header.flags = 0;
+        header.sessionId = sessionId;
+
+        rnp::PacketPingPong pong{};
+        pong.nonce = nonce;
+        pong.sendTimeMs = static_cast<std::uint32_t>(
+            std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now().time_since_epoch())
+                .count());
+
+        serializer.serializeHeader(header);
+        serializer.serializePingPong(pong);
+
+        sendPacketImmediate(serializer.getData(), destination);
+    }
+
+    void AsioServer::sendConnectAccept(std::uint32_t sessionId, const asio::ip::udp::endpoint &destination)
+    {
+        utl::Logger::log("AsioServer: Preparing CONNECT_ACCEPT packet for session " + std::to_string(sessionId) +
+                             " to " + destination.address().to_string() + ":" + std::to_string(destination.port()),
+                         utl::LogLevel::INFO);
+
+        rnp::Serializer serializer;
+        rnp::PacketHeader header{};
+        header.type = static_cast<std::uint8_t>(rnp::PacketType::CONNECT_ACCEPT);
+        header.length = sizeof(rnp::PacketConnectAccept);
+        header.flags = 0;
+        header.sessionId = sessionId;
+
+        rnp::PacketConnectAccept accept{};
+        accept.sessionId = sessionId;
+        accept.tickRateHz = m_tickRate;
+        accept.mtuPayloadBytes = rnp::MAX_PAYLOAD;
+        accept.serverCaps = m_serverCaps;
+
+        serializer.serializeHeader(header);
+        serializer.serializeConnectAccept(accept);
+
+        utl::Logger::log("AsioServer: Sending CONNECT_ACCEPT packet (" + std::to_string(serializer.getData().size()) +
+                             " bytes)",
+                         utl::LogLevel::INFO);
+        sendPacketImmediate(serializer.getData(), destination);
+    }
+
+    void AsioServer::sendError(rnp::ErrorCode errorCode, const std::string &description,
+                               const asio::ip::udp::endpoint &destination, std::uint32_t sessionId)
+    {
+        rnp::Serializer serializer;
+        rnp::PacketHeader header{};
+        header.type = static_cast<std::uint8_t>(rnp::PacketType::PACKET_ERROR);
+        header.length = static_cast<std::uint16_t>(sizeof(rnp::PacketError) + description.length());
+        header.flags = 0;
+        header.sessionId = sessionId;
+
+        rnp::PacketError error{};
+        error.errorCode = static_cast<std::uint16_t>(errorCode);
+        error.msgLen = static_cast<std::uint16_t>(description.length());
+        error.description = description;
+
+        serializer.serializeHeader(header);
+        serializer.serializeError(error);
+
+        sendPacketImmediate(serializer.getData(), destination);
+    }
+
+    void AsioServer::updateClientManagement()
+    {
+        auto now = std::chrono::steady_clock::now();
+
+        // Send pings periodically
+        if (now - m_lastPingTime > m_pingInterval)
+        {
+            std::lock_guard<std::mutex> lock(m_clientsMutex);
+            for (auto &[sessionId, client] : m_clients)
+            {
+                if (client.isConnected)
+                {
+                    // Send ping
+                    rnp::Serializer serializer;
+                    rnp::PacketHeader header{};
+                    header.type = static_cast<std::uint8_t>(rnp::PacketType::PING);
+                    header.length = sizeof(rnp::PacketPingPong);
+                    header.flags = 0;
+                    header.sessionId = sessionId;
+
+                    rnp::PacketPingPong ping{};
+                    ping.nonce = ++client.lastPingSent;
+                    ping.sendTimeMs = static_cast<std::uint32_t>(
+                        std::chrono::duration_cast<std::chrono::milliseconds>(now.time_since_epoch()).count());
+
+                    serializer.serializeHeader(header);
+                    serializer.serializePingPong(ping);
+
+                    std::lock_guard<std::mutex> queueLock(m_sendQueueMutex);
+                    m_sendQueue.emplace(serializer.getData(), client.endpoint, false);
+                }
+            }
+            m_lastPingTime = now;
+        }
+
+        // Check for timeouts
+        std::vector<std::uint32_t> timedOutClients;
+        {
+            std::lock_guard<std::mutex> lock(m_clientsMutex);
+            for (const auto &[sessionId, client] : m_clients)
+            {
+                if (client.isConnected && (now - client.lastSeen) > m_clientTimeout)
+                {
+                    timedOutClients.push_back(sessionId);
+                }
+            }
+        }
+
+        // Disconnect timed out clients
+        for (std::uint32_t sessionId : timedOutClients)
+        {
+            utl::Logger::log("AsioServer: Client " + std::to_string(sessionId) + " timed out", utl::LogLevel::INFO);
+            disconnectClient(sessionId);
+        }
+    }
+
+    void AsioServer::processSendQueue()
+    {
+        std::lock_guard<std::mutex> lock(m_sendQueueMutex);
+        while (!m_sendQueue.empty())
+        {
+            const QueuedPacket &packet = m_sendQueue.front();
+            sendPacketImmediate(packet.data, packet.destination);
+            m_sendQueue.pop();
+        }
+    }
+
+} // namespace srv

--- a/plugins/Network/Asio/Server/src/entrypoint.cpp
+++ b/plugins/Network/Asio/Server/src/entrypoint.cpp
@@ -1,6 +1,7 @@
 #include <memory>
 
 #include "AsioServer/AsioServer.hpp"
+#include "Utils/Interfaces/IPlugin.hpp"
 
 extern "C"
 {

--- a/server/src/server.cpp
+++ b/server/src/server.cpp
@@ -11,9 +11,8 @@ srv::Server::Server(const ArgsConfig &config)
       m_network(m_pluginLoader->loadPlugin<INetworkServer>(!config.network_lib_path.empty()
                                                                ? config.network_lib_path
                                                                : Path::Plugin::PLUGINS_NETWORK_ASIO_SERVER.string())),
-      m_game(m_pluginLoader->loadPlugin<gme::IGameServer>(!config.game_lib_path.empty()
-                                                                ? config.game_lib_path
-                                                         : Path::Plugin::PLUGINS_GAME_RTYPE_SERVER.string()))
+      m_game(m_pluginLoader->loadPlugin<gme::IGameServer>(
+          !config.game_lib_path.empty() ? config.game_lib_path : Path::Plugin::PLUGINS_GAME_RTYPE_SERVER.string()))
 {
     utl::Logger::log("PROJECT INFO:", utl::LogLevel::INFO);
     std::cout << "\tName: " PROJECT_NAME "\n"
@@ -31,6 +30,19 @@ void srv::Server::run() const
     m_network->start();
     for (;;)
     {
+        m_network->update();
+
+        // Print connected sessions
+        auto sessions = m_network->getConnectedSessions();
+        std::cout << "Connected sessions (" << sessions.size() << "): ";
+        for (size_t i = 0; i < sessions.size(); ++i)
+        {
+            std::cout << sessions[i];
+            if (i < sessions.size() - 1)
+                std::cout << ", ";
+        }
+        std::cout << std::endl;
+
         std::this_thread::sleep_for(std::chrono::seconds(1));
     }
 }


### PR DESCRIPTION
Introduce rnp::HandlerPacket and Serializer for packet parsing/serialization. Simplify and adjust Protocol payloads and header layout (flags, types, arrays). Update INetworkClient/INetworkServer APIs (connection state, update(), send APIs, player name/capabilities, stats and getters). Rewrite Asio client and server implementations to use async IO, send queues, packet handlers, connection/timeouts, logging and statistics. Update CMake includes and plugin entrypoints. Server main loop now calls network->update() and prints sessions.